### PR TITLE
Set minimum width on award number columns to avoid excessive wrapping

### DIFF
--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -42,6 +42,7 @@ export default Controller.extend({
     {
       propertyName: 'grant.awardNumber',
       title: 'Award Number',
+      className: 'awardnum-column',
       disableFiltering: true,
       component: 'grant-link-cell'
     },
@@ -98,6 +99,7 @@ export default Controller.extend({
     {
       propertyName: 'grant.awardNumber',
       title: 'Award #',
+      className: 'awardnum-column',
       disableFiltering: true,
       component: 'grant-link-cell'
     },

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -34,6 +34,7 @@ export default Controller.extend({
   {
     title: 'Award Number (Funder)',
     propertyName: 'grantInfo',
+    className: 'awardnum-funder-column',
     component: 'submissions-award-cell',
     disableSorting: true
   },
@@ -76,6 +77,7 @@ export default Controller.extend({
   },
   {
     title: 'Award Number (Funder)',
+    className: 'awardnum-funder-column',
     component: 'submissions-award-cell'
   },
   {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -672,3 +672,5 @@ table td {
 .title-column { min-width: 400px; }
 .msid-column { min-width: 145px; }
 .actions-column { min-width: 125px; }
+.awardnum-column { min-width: 125px; }
+.awardnum-funder-column { min-width: 150px; }

--- a/app/templates/components/submission-funding-table.hbs
+++ b/app/templates/components/submission-funding-table.hbs
@@ -9,7 +9,7 @@
   <tbody>
     {{#each grants as |grant|}}
       <tr class="pr-0">
-        <td>
+        <td class="awardnum-column">
           {{#link-to "grants.detail" grant}}{{grant.awardNumber}}{{/link-to}}
         </td>
         <td>{{grant.projectName}}</td>


### PR DESCRIPTION
Several places in the system have award numbers wrapping awkwardly. This sets a minimum width for several  `Award number` and `Award number (funder)` columns. Specifically:
* the award number column in the Grants workflow step now has a min-width (#443)
* the award number (funder) column in Your Submissions now has a min-width (#520)
* the award number column in Your Grants now has a min-width

To test, make the browser window narrow on each of these pages and verify that the wrap-size is reasonable.

Closes #520, #443
