### PR TITLE
Deal with different expression of timeout in production

### DIFF
--- a/app/components/workflow-component.js
+++ b/app/components/workflow-component.js
@@ -13,6 +13,8 @@ export default Component.extend({
       if (!(data.username)) {
         this.get('errorHandler').handleError(new Error('shib302'));
       }
+    }).fail(function () {
+      this.get('errorHandler').handleError(new Error('shib302'));
     });
   }
 });

--- a/app/routes/check-session-route.js
+++ b/app/routes/check-session-route.js
@@ -14,6 +14,9 @@ export default Route.extend({
         transition.abort();
         this.get('errorHandler').handleError(new Error('shib302'));
       }
+    }).fail(function () {
+      transition.abort();
+      this.get('errorHandler').handleError(new Error('shib302'));
     });
   }
 });


### PR DESCRIPTION
In production, timeout results in an error being thrown by whoami due to the fact shib is on a different domain name and js can't reach it. The error is caught by the default error handler instead so the default error is shown instead of the timeout error. This adds a catch so that the timeout error is shown when whoami fails.  To test, see instructions for #711 