### PR TITLE
Fix husky setup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -105,3 +105,9 @@ You can run also run tests, but you may have to install other dependencies such 
 
 If you wish, you may install ember locally. The application will not be able to run due to the need to access various web services,
 but running tests on the command line can be useful. See documentation at [ember.js](https://emberjs.com/). There may be dependency issues requiring node-sass to be rebuilt for your environment.
+
+### Linting
+
+This project uses `es-lint`, `ember-template-lint` and `prettier` to enforce style decisions and code formatting. You may consider installing [an integration tool](https://prettier.io/docs/en/editors.html) for your editor of choice.
+
+This project uses (husky)[https://github.com/typicode/husky] to run a command from (lint-staged)[https://github.com/okonet/lint-staged] to run `es-lint --fix` and `prettier --write` over the staged files in a pre-commit hook. If you are unable to make a commit it might be because either one or both of these commands has failed. Check the output in the terminal for what failures have occurred.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "ember build --environment=production",
     "start": "ember server",
-    "test": "ember test"
+    "test": "ember test",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
@@ -48,7 +49,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-qunit": "^7.2.0",
-    "husky": "^7.0.0",
+    "husky": "^8.0.0",
     "lint-staged": "^10.2.13",
     "lint-to-the-future": "^1.1.0",
     "lint-to-the-future-ember-template": "^1.0.0",
@@ -64,8 +65,9 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
-      "eslint --fix"
+    "*.{js,ts}": [
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ]
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">= 14"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Addresses: https://github.com/eclipse-pass/main/issues/228

- this runs the husky init cmd which is required to make husky work
- this adds the lint-staged cmd to the husky pre-commit file
- this also updates what cmds are run by lint-staged to include prettier
and gets rid of the unrelated file types

This is an example of what would happen if you attempted to commit something that violates an es-lint rule. Here I added a debugger intentionally and tried to commit it:

![Screen Shot 2022-05-23 at 10 37 12 AM](https://user-images.githubusercontent.com/6305935/169844016-48de5192-a77f-4650-aa8a-a97e7dd118a6.png)
