### PR TITLE
Using enums

### DIFF
--- a/app/models/contributor.js
+++ b/app/models/contributor.js
@@ -13,3 +13,10 @@ export default class ContributorModel extends Model {
   @belongsTo('user') user;
   @belongsTo('publication') publication;
 }
+
+export const Role = {
+  AUTHOR: 'AUTHOR',
+  FIRST_AUTHOR: 'FIRST_AUTHOR',
+  LAST_AUTHOR: 'LAST_AUTHOR',
+  CORRESPONDING_AUTHOR: 'CORRESPONDING_AUTHOR',
+};

--- a/app/models/deposit.js
+++ b/app/models/deposit.js
@@ -2,7 +2,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class DepositModel extends Model {
   @attr('string') depositStatusRef;
-  @attr('string') depositStatus;
+  @attr('enum') depositStatus;
 
   @belongsTo('repositoryCopy') repositoryCopy;
   @belongsTo('submission') submission;

--- a/app/models/deposit.js
+++ b/app/models/deposit.js
@@ -8,3 +8,10 @@ export default class DepositModel extends Model {
   @belongsTo('submission') submission;
   @belongsTo('repository') repository;
 }
+
+export const DepositStatus = {
+  SUBMITTED: 'SUBMITTED',
+  REJECTED: 'REJECTED',
+  FAILED: 'FAILED',
+  ACCEPTED: 'ACCEPTED',
+};

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -4,7 +4,7 @@ export default class FileModel extends Model {
   @attr('string') name;
   @attr('string') description;
   /** Possible values: manuscript, supplemental, table, figure */
-  @attr('string') fileRole;
+  @attr('enum') fileRole;
   @attr('string') uri;
   @attr('string') mimeType;
 

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -13,3 +13,10 @@ export default class FileModel extends Model {
   // not represented on backend
   @attr('string') _file;
 }
+
+export const Role = {
+  MANUSCRIPT: 'MANUSCRIPT',
+  SUPPLEMENTAL: 'SUPPLEMENTAL',
+  FIGURE: 'FIGURE',
+  TABLE: 'TABLE',
+};

--- a/app/models/journal.js
+++ b/app/models/journal.js
@@ -1,6 +1,7 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes */
 import Model, { attr, belongsTo } from '@ember-data/model';
 import { computed } from '@ember/object';
+import { PMCParticipation as PublisherPMCParticipation } from './publisher';
 
 export default class JournalModel extends Model {
   /**
@@ -15,11 +16,14 @@ export default class JournalModel extends Model {
 
   @computed('pmcParticipation')
   get isMethodA() {
-    return this.pmcParticipation ? this.pmcParticipation.toLowerCase() === 'a' : false;
+    return this.pmcParticipation ? this.pmcParticipation.toLowerCase() === PMCParticipation.A : false;
   }
 
   @computed('pmcParticipation')
   get isMethodB() {
-    return this.pmcParticipation ? this.pmcParticipation.toLowerCase() === 'b' : false;
+    return this.pmcParticipation ? this.pmcParticipation.toLowerCase() === PMCParticipation.B : false;
   }
 }
+
+/** Re-export from Publisher model, since they use th same codes */
+export const PMCParticipation = PublisherPMCParticipation;

--- a/app/models/journal.js
+++ b/app/models/journal.js
@@ -16,12 +16,12 @@ export default class JournalModel extends Model {
 
   @computed('pmcParticipation')
   get isMethodA() {
-    return this.pmcParticipation ? this.pmcParticipation.toLowerCase() === PMCParticipation.A : false;
+    return this.pmcParticipation ? this.pmcParticipation === PMCParticipation.A : false;
   }
 
   @computed('pmcParticipation')
   get isMethodB() {
-    return this.pmcParticipation ? this.pmcParticipation.toLowerCase() === PMCParticipation.B : false;
+    return this.pmcParticipation ? this.pmcParticipation === PMCParticipation.B : false;
   }
 }
 

--- a/app/models/publisher.js
+++ b/app/models/publisher.js
@@ -14,3 +14,10 @@ export default class PublisherModel extends Model {
    */
   @attr('string') pmcParticipation;
 }
+
+export const PMCParticipation = {
+  A: 'A',
+  B: 'B',
+  C: 'C',
+  D: 'D',
+};

--- a/app/models/repository-copy.js
+++ b/app/models/repository-copy.js
@@ -8,3 +8,11 @@ export default class RepositoryCopyModel extends Model {
   @belongsTo('publication') publication;
   @belongsTo('repository') repository;
 }
+
+export const CopyStatus = {
+  ACCEPTED: 'ACCEPTED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  STALLED: 'STALLED',
+  COMPLETE: 'COMPLETE',
+  REJECTED: 'REJECTED',
+};

--- a/app/models/repository-copy.js
+++ b/app/models/repository-copy.js
@@ -3,7 +3,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class RepositoryCopyModel extends Model {
   @attr('set') externalIds;
   @attr('string') accessUrl;
-  @attr('string') copyStatus;
+  @attr('enum') copyStatus;
 
   @belongsTo('publication') publication;
   @belongsTo('repository') repository;

--- a/app/models/repository.js
+++ b/app/models/repository.js
@@ -15,7 +15,7 @@ export default class RepositoryModel extends Model {
 
   @computed('integrationType')
   get _isWebLink() {
-    return this.integrationType === IntegrationType.WEB_LINK;
+    return this.integrationType === 'web-link';
   }
 }
 

--- a/app/models/repository.js
+++ b/app/models/repository.js
@@ -15,6 +15,21 @@ export default class RepositoryModel extends Model {
 
   @computed('integrationType')
   get _isWebLink() {
-    return this.integrationType === 'web-link';
+    return this.integrationType === IntegrationType.WEB_LINK;
   }
 }
+
+export const IntegrationType = {
+  FULL: 'FULL',
+  ONE_WAY: 'ONE_WAY',
+  WEB_LINK: 'WEB_LINK',
+};
+
+// String field, not enum
+export const KnownKeys = {
+  PMC: 'pmc',
+  JSCHOLARSHIP: 'jscholarship',
+  ERIC: 'eric',
+  DEC: 'dec',
+  DASH: 'dash',
+};

--- a/app/models/repository.js
+++ b/app/models/repository.js
@@ -7,9 +7,9 @@ export default class RepositoryModel extends Model {
   @attr('string') description;
   @attr('string') url;
   @attr('string') formSchema;
-  @attr('string') integrationType;
+  @attr('enum') integrationType;
   @attr('string', { defaultValue: false }) agreementText;
-  @attr('string') repositoryKey;
+  @attr('enum') repositoryKey;
 
   @attr('boolean') _selected;
 

--- a/app/models/submission-event.js
+++ b/app/models/submission-event.js
@@ -1,9 +1,9 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class SubmissionEventModel extends Model {
-  @attr('string') eventType;
+  @attr('enum') eventType;
   @attr('date') performedDate;
-  @attr('string') performerRole;
+  @attr('enum') performerRole;
   @attr('string') comment;
   @attr('string') link;
 

--- a/app/models/submission-event.js
+++ b/app/models/submission-event.js
@@ -10,3 +10,16 @@ export default class SubmissionEventModel extends Model {
   @belongsTo('submission') submission;
   @belongsTo('user') performedBy;
 }
+
+export const Type = {
+  APPROVAL_REQUESTED_NEWUSER: 'APPROVAL_REQUESTED_NEWUSER',
+  APPROVAL_REQUESTED: 'APPROVAL_REQUESTED',
+  CHANGES_REQUESTED: 'CHANGES_REQUESTED',
+  CANCELLED: 'CANCELLED',
+  SUBMITTED: 'SUBMITTED',
+};
+
+export const Performer = {
+  PREPARER: 'PREPARER',
+  SUBMITTER: 'SUBMITTER',
+};

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -5,11 +5,11 @@ import { computed, get } from '@ember/object';
 export default class SubmissionModel extends Model {
   /** Possible values: not-started, in-progress, accepted */
   @attr('string', {
-    defaultValue: SubmissionStatus.NOT_STARTED,
+    defaultValue: () => SubmissionStatus.NOT_STARTED,
   })
   aggregatedDepositStatus;
   @attr('date') submittedDate;
-  @attr('string', { defaultValue: Source.PASS }) source;
+  @attr('string', { defaultValue: () => Source.PASS }) source;
   @attr('string') metadata;
   @attr('boolean', { defaultValue: false }) submitted;
   @attr('string') submissionStatus;

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -4,15 +4,15 @@ import { computed, get } from '@ember/object';
 
 export default class SubmissionModel extends Model {
   /** Possible values: not-started, in-progress, accepted */
-  @attr('string', {
-    defaultValue: () => SubmissionStatus.NOT_STARTED,
+  @attr('enum', {
+    defaultValue: 'not-started',
   })
   aggregatedDepositStatus;
   @attr('date') submittedDate;
-  @attr('string', { defaultValue: () => Source.PASS }) source;
+  @attr('enum', { defaultValue: 'pass' }) source;
   @attr('string') metadata;
   @attr('boolean', { defaultValue: false }) submitted;
-  @attr('string') submissionStatus;
+  @attr('enum') submissionStatus;
   @attr('string') submitterName;
   @attr('string', {
     defaultValue: null,
@@ -94,7 +94,7 @@ export default class SubmissionModel extends Model {
 
   @computed('source', 'submitted')
   get isStub() {
-    return this.source === Source.OTHER && !this.submitted;
+    return this.source === 'other' && !this.submitted;
   }
 
   /**
@@ -102,7 +102,7 @@ export default class SubmissionModel extends Model {
    */
   @computed('submitted', 'submissionStatus')
   get isDraft() {
-    return this.submissionStatus === SubmissionStatus.DRAFT;
+    return this.submissionStatus === 'draft';
   }
 
   /**

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -5,11 +5,11 @@ import { computed, get } from '@ember/object';
 export default class SubmissionModel extends Model {
   /** Possible values: not-started, in-progress, accepted */
   @attr('string', {
-    defaultValue: 'NOT_STARTED',
+    defaultValue: SubmissionStatus.NOT_STARTED,
   })
   aggregatedDepositStatus;
   @attr('date') submittedDate;
-  @attr('string', { defaultValue: 'PASS' }) source;
+  @attr('string', { defaultValue: Source.PASS }) source;
   @attr('string') metadata;
   @attr('boolean', { defaultValue: false }) submitted;
   @attr('string') submissionStatus;
@@ -94,7 +94,7 @@ export default class SubmissionModel extends Model {
 
   @computed('source', 'submitted')
   get isStub() {
-    return this.source === 'other' && !this.submitted;
+    return this.source === Source.OTHER && !this.submitted;
   }
 
   /**
@@ -102,7 +102,7 @@ export default class SubmissionModel extends Model {
    */
   @computed('submitted', 'submissionStatus')
   get isDraft() {
-    return this.submissionStatus === 'draft';
+    return this.submissionStatus === SubmissionStatus.DRAFT;
   }
 
   /**
@@ -121,3 +121,27 @@ export default class SubmissionModel extends Model {
     return false;
   }
 }
+
+export const SubmissionStatus = {
+  DRAFT: 'DRAFT',
+  MANUSCRIPT_REQUIRED: 'MANUSCRIPT_REQUIRED',
+  APPROVAL_REQUESTED: 'APPROVAL_REQUESTED',
+  CHANGES_REQUESTED: 'CHANGES_REQUESTED',
+  CANCELLED: 'CANCELLED',
+  SUBMITTED: 'SUBMITTED',
+  NEEDS_ATTENTION: 'NEEDS_ATTENTION',
+  COMPLETE: 'COMPLETE',
+};
+
+export const AggregatedDepositStatus = {
+  NOT_STARTED: 'NOT_STARTED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  FAILED: 'FAILED',
+  ACCEPTED: 'ACCEPTED',
+  REJECTED: 'REJECTED',
+};
+
+export const Source = {
+  PASS: 'PASS',
+  OTHER: 'OTHER',
+};

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -21,12 +21,12 @@ export default class UserModel extends Model {
 
   @computed('roles.[]')
   get isSubmitter() {
-    return this.roles ? this.roles.includes('submitter') || this.roles.includes('SUBMITTER') : false;
+    return this.roles ? this.roles.includes(Role.SUBMITTER) : false;
   }
 
   @computed('roles.[]')
   get isAdmin() {
-    return this.roles ? this.roles.includes('admin') || this.roles.includes('ADMIN') : false;
+    return this.roles ? this.roles.includes(Role.ADMIN) : false;
   }
 }
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -29,3 +29,8 @@ export default class UserModel extends Model {
     return this.roles ? this.roles.includes('admin') || this.roles.includes('ADMIN') : false;
   }
 }
+
+export const Role = {
+  SUBMITTER: 'SUBMITTER',
+  ADMIN: 'ADMIN',
+};

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -21,12 +21,12 @@ export default class UserModel extends Model {
 
   @computed('roles.[]')
   get isSubmitter() {
-    return this.roles ? this.roles.includes(Role.SUBMITTER) : false;
+    return this.roles ? this.roles.includes('submitter') : false;
   }
 
   @computed('roles.[]')
   get isAdmin() {
-    return this.roles ? this.roles.includes(Role.ADMIN) : false;
+    return this.roles ? this.roles.includes('admin') : false;
   }
 }
 

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -2,6 +2,7 @@
 import CheckSessionRoute from './check-session-route';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
+import { SubmissionStatus } from 'pass-ui/models/submission';
 
 export default class DashboardRoute extends CheckSessionRoute {
   @service('current-user') currentUser;
@@ -12,11 +13,11 @@ export default class DashboardRoute extends CheckSessionRoute {
     const userId = get(this, 'currentUser.user.id');
 
     const awaitingApproval = await this.store.query('submission', {
-      filter: { submission: `submitter.id==${userId};submissionStatus==APPROVAL_REQUESTED` },
+      filter: { submission: `submitter.id==${userId};submissionStatus==${SubmissionStatus.APPROVAL_REQUESTED}` },
     });
 
     const awaitingChanges = await this.store.query('submission', {
-      filter: { submission: `preparers.id==${userId};submissionStatus==CHANGES_REQUESTED` },
+      filter: { submission: `preparers.id==${userId};submissionStatus==${SubmissionStatus.CHANGES_REQUESTED}` },
     });
 
     return {

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -2,7 +2,6 @@
 import CheckSessionRoute from './check-session-route';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
-import { SubmissionStatus } from 'pass-ui/models/submission';
 
 export default class DashboardRoute extends CheckSessionRoute {
   @service('current-user') currentUser;
@@ -13,11 +12,11 @@ export default class DashboardRoute extends CheckSessionRoute {
     const userId = get(this, 'currentUser.user.id');
 
     const awaitingApproval = await this.store.query('submission', {
-      filter: { submission: `submitter.id==${userId};submissionStatus==${SubmissionStatus.APPROVAL_REQUESTED}` },
+      filter: { submission: `submitter.id==${userId};submissionStatus==APPROVAL_REQUESTED` },
     });
 
     const awaitingChanges = await this.store.query('submission', {
-      filter: { submission: `preparers.id==${userId};submissionStatus==${SubmissionStatus.CHANGES_REQUESTED}` },
+      filter: { submission: `preparers.id==${userId};submissionStatus==CHANGES_REQUESTED` },
     });
 
     return {

--- a/app/transforms/enum.js
+++ b/app/transforms/enum.js
@@ -1,0 +1,25 @@
+import Transform from '@ember-data/serializer/transform';
+import { dasherize, underscore } from '@ember/string';
+
+/**
+ * Some model attributes are represented by enumerations on the backend.
+ * These values were previously represented by by dasherized string
+ * values. However, due to a bug in our demo endpoint, the values have
+ * changed to underscored strings.
+ *
+ * This transform will dynamically change the value back to the
+ * dasherized value for the Ember side and back to the underscore
+ * value when passed to the backend.
+ *
+ * TODO: we can have a proper enum implementation here by passing
+ * the possible values in `options` and checking values at
+ * serialization time.
+ */
+export default class EnumTransform extends Transform {
+  serialize(deserialized, options) {
+    return underscore(deserialized).toUpperCase();
+  }
+  deserialize(serialized, options) {
+    return dasherize(serialized).toLowerCase();
+  }
+}


### PR DESCRIPTION
* New 'enum'-like attr type for select attributes
* Custom 'enum' transform
* Update appropriate models to use the new type

Notes:
* `store.query` filters still must use the UPPER_SNAKE_CASE values, as they are currently passed directly to the backend
* Enum exports from model files are maintained for reference. We can remove these if necessary