### PR TITLE
Fix host and passthroughs

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -6,7 +6,6 @@ import ENV from 'pass-ui/config/environment';
  * PASS specific extensions for Ember Data's JSON:API adapter
  */
 export default class ApplicationAdapter extends JSONAPIAdapter {
-  host = ENV.passApi.host;
   namespace = ENV.passApi.namespace;
 
   headers = {

--- a/app/authenticators/http-only.js
+++ b/app/authenticators/http-only.js
@@ -19,7 +19,7 @@ export default class HttpOnly extends Base {
   restore(data) {
     return new RSVP.Promise((resolve, reject) => {
       if (!this._validateData(data)) {
-        return reject('Could not restore session - "access_token" missing.');
+        return reject('Could not restore session - "user" missing.');
       }
 
       return resolve(data);
@@ -59,6 +59,6 @@ export default class HttpOnly extends Base {
   _validateData(data) {
     // see https://tools.ietf.org/html/rfc6749#section-4.2.2
 
-    return !isEmpty(data) && !isEmpty(data.access_token);
+    return !isEmpty(data) && !isEmpty(data.user.id);
   }
 }

--- a/app/components/nav-bar/index.js
+++ b/app/components/nav-bar/index.js
@@ -33,11 +33,6 @@ export default class NavBar extends Component {
   }
 
   @action
-  invalidateSession() {
-    // get(this, 'session').invalidate();
-  }
-
-  @action
   scrollToAnchor() {
     if (window.location.search.indexOf('anchor=') == -1) {
       window.scrollTo(0, 0);

--- a/app/routes/check-session-route.js
+++ b/app/routes/check-session-route.js
@@ -1,8 +1,7 @@
 /* eslint-disable ember/no-jquery */
-/* eslint-disable no-debugger */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { action, get } from '@ember/object';
+import { action } from '@ember/object';
 
 export default class CheckSessionRouteRoute extends Route {
   @service toast;
@@ -13,7 +12,9 @@ export default class CheckSessionRouteRoute extends Route {
   errorHandler;
 
   async beforeModel() {
-    await this._loadCurrentUser();
+    if (!this.currentUser.user) {
+      await this._loadCurrentUser();
+    }
 
     if (!this.session.isAuthenticated) {
       this.session.set('attemptedTransition', transition);

--- a/config/environment.js
+++ b/config/environment.js
@@ -11,7 +11,6 @@ module.exports = function (environment) {
     // Config for ember-data backend calls
     passApi: {
       namespace: process.env.PASS_API_NAMESPACE || 'api/v1',
-      host: process.env.PASS_API_URL || 'http://localhost:8080',
     },
     locationType: 'auto',
     'ember-load': {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -102,8 +102,8 @@ export default function (config) {
       // // Grants
       // this.get('/grant/:id');
 
-      this.passthrough('http://localhost*');
-      this.passthrough('https://localhost*');
+      this.passthrough('http://localhost/**');
+      this.passthrough('https://localhost/**');
       this.passthrough();
     },
   };


### PR DESCRIPTION
- setting the host in the adapter is unnecessary because ember will default to the current host by default, which is more flexible than requiring it to be set
- this removes the setting of host
- this also fixes an issue with passthrough which were not capturing fully qualified domains
- some misc cleanup as well