### PR TITLE
Fix stale session hang bug

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,11 +1,14 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { camelize } from '@ember/string';
 import ENV from 'pass-ui/config/environment';
+import { inject as service } from '@ember/service';
 
 /**
  * PASS specific extensions for Ember Data's JSON:API adapter
  */
 export default class ApplicationAdapter extends JSONAPIAdapter {
+  @service session;
+
   namespace = ENV.passApi.namespace;
 
   headers = {


### PR DESCRIPTION
- the session service wasn't being injected which meant `session.invalidate` was never being called
- this caused two bugs:
1) stale sessions would hang on network interactions after becoming stale and the error handler service would trap things in the modal;
2) a re-authentication after this hang would further hang when hitting the `auth/callback` route (probably because the client side session was still in place.
- injecting the session allows the session to be invalidated properly