### PR TITLE
Fix som JSON API filters

### DIFF
--- a/app/components/workflow-basics-user-search/index.js
+++ b/app/components/workflow-basics-user-search/index.js
@@ -44,7 +44,7 @@ export default class WorkflowBasicsUserSearch extends Component {
   }
 
   userFilter(input) {
-    const match = `=ini=*${input}*`;
+    const match = `=ini="*${input}*"`;
     return [`firstName${match}`, `middleName${match}`, `lastName${match}`, `email${match}`, `displayName${match}`].join(
       ','
     );
@@ -63,7 +63,7 @@ export default class WorkflowBasicsUserSearch extends Component {
     // TODO: sanitize input before building filter!!
     const userQuery = {
       filter: {
-        user: `email=isnull=false;${this.userFilter(input)}`,
+        user: `email=isnull=false;(${this.userFilter(input)})`,
       },
       page: {
         offset: (page - 1) * size,

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -54,9 +54,10 @@ export default class IndexRoute extends CheckSessionRoute {
         });
       });
 
+      const userMatch = `grants.pi.id==${userId},grants.coPis.id==${userId}`;
       const submissionQuery = {
         filter: {
-          submission: `submissionStatus=out=cancelled;grants.pi.id==${userId},grants.coPis.id==${userId}`,
+          submission: `submissionStatus=out=cancelled;(${userMatch})`,
         },
       };
 

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -19,7 +19,11 @@ export default class IndexRoute extends CheckSessionRoute {
       };
     } else if (user.get('isSubmitter')) {
       query = {
-        filter: { submission: `submitter.id==${user.get('id')};submissionStatus=out=cancelled` },
+        filter: {
+          submission: `submitter.id==${user.get('id')},preparers.id=in=${user.get(
+            'id'
+          )};submissionStatus=out=cancelled`,
+        },
         sort: '-submittedDate',
       };
     }

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -18,11 +18,10 @@ export default class IndexRoute extends CheckSessionRoute {
         filter: { submission: 'submissionStatus=out=cancelled' },
       };
     } else if (user.get('isSubmitter')) {
+      const userMatch = `submitter.id==${user.get('id')},preparers.id=in=${user.get('id')}`;
       query = {
         filter: {
-          submission: `submitter.id==${user.get('id')},preparers.id=in=${user.get(
-            'id'
-          )};submissionStatus=out=cancelled`,
+          submission: `(${userMatch});submissionStatus=outi=cancelled`,
         },
         sort: '-submittedDate',
       };

--- a/app/services/autocomplete.js
+++ b/app/services/autocomplete.js
@@ -48,7 +48,7 @@ export default class AutocompleteService extends Service {
 
     const query = Object.assign({ filter: {} }, context);
 
-    const suggestFilterPart = fieldName.map((field) => `${field}=ini=*${suggestPrefix}*`).join(',');
+    const suggestFilterPart = fieldName.map((field) => `${field}=ini="*${suggestPrefix}*"`).join(',');
 
     // Append the suggest filter piece to the existing type filter, if it exists
     query.filter[type] = query.filter[type] ? `${query.filter[type]};${suggestFilterPart}` : suggestFilterPart;


### PR DESCRIPTION
Resolves https://github.com/eclipse-pass/main/issues/372

A few JSON:API filters needed to be grouped correctly with parenthesis. Some JSON:API filter parts needed to be surrounded by double quotes, if a space could appear in the filter string.

* Submission workflow, Basics step, user search
* Grants list page
* Submissions list page
* Journal autocomplete search

Submissions list page also was not matching against `preparers` 