### PR TITLE
Fix stale auth bug 2

### DIFF
--- a/app/authenticators/http-only.js
+++ b/app/authenticators/http-only.js
@@ -18,6 +18,9 @@ export default class HttpOnly extends Base {
    */
   restore(data) {
     return new RSVP.Promise((resolve, reject) => {
+      if (window.location.pathname === '/app/auth-callback') {
+        return reject('Could not restore session.');
+      }
       if (!this._validateData(data)) {
         return reject('Could not restore session.');
       }

--- a/app/authenticators/http-only.js
+++ b/app/authenticators/http-only.js
@@ -19,7 +19,7 @@ export default class HttpOnly extends Base {
   restore(data) {
     return new RSVP.Promise((resolve, reject) => {
       if (!this._validateData(data)) {
-        return reject('Could not restore session - "user" missing.');
+        return reject('Could not restore session.');
       }
 
       return resolve(data);
@@ -56,9 +56,20 @@ export default class HttpOnly extends Base {
     });
   }
 
-  _validateData(data) {
+  async _validateData(data) {
     // see https://tools.ietf.org/html/rfc6749#section-4.2.2
+    if (isEmpty(data) || isEmpty(data.user.id)) return false;
 
-    return !isEmpty(data) && !isEmpty(data.user.id);
+    const url = `${window.location.origin}/authenticated`;
+
+    let response = await fetch(url);
+
+    if (response.ok) {
+      const refreshedData = await response.json();
+
+      return data.user.id === refreshedData.user.id;
+    } else {
+      return false;
+    }
   }
 }

--- a/app/routes/auth-callback.js
+++ b/app/routes/auth-callback.js
@@ -11,8 +11,9 @@ export default class AuthCallbackRoute extends Route {
         const url = `${window.location.origin}/authenticated`;
 
         let response = await fetch(url);
+        const data = await response.json();
 
-        if (response.ok) {
+        if (response.ok && data.user.id === this.session.data.authenticated.user.id) {
           this.transitionTo('dashboard');
         } else {
           await this.session.invalidate();

--- a/app/routes/auth-callback.js
+++ b/app/routes/auth-callback.js
@@ -7,7 +7,19 @@ export default class AuthCallbackRoute extends Route {
 
   async beforeModel() {
     try {
-      await this.session.authenticate('authenticator:http-only');
+      if (this.session.isAuthenticated) {
+        const url = `${window.location.origin}/authenticated`;
+
+        let response = await fetch(url);
+
+        if (response.ok) {
+          this.transitionTo('dashboard');
+        } else {
+          await this.session.invalidate();
+        }
+      } else {
+        await this.session.authenticate('authenticator:http-only');
+      }
     } catch (error) {
       window.location.replace(`${window.location.origin}/logout`);
     }

--- a/app/routes/auth-callback.js
+++ b/app/routes/auth-callback.js
@@ -7,20 +7,7 @@ export default class AuthCallbackRoute extends Route {
 
   async beforeModel() {
     try {
-      if (this.session.isAuthenticated) {
-        const url = `${window.location.origin}/authenticated`;
-
-        let response = await fetch(url);
-        const data = await response.json();
-
-        if (response.ok && data.user.id === this.session.data.authenticated.user.id) {
-          this.transitionTo('dashboard');
-        } else {
-          await this.session.invalidate();
-        }
-      } else {
-        await this.session.authenticate('authenticator:http-only');
-      }
+      await this.session.authenticate('authenticator:http-only');
     } catch (error) {
       window.location.replace(`${window.location.origin}/logout`);
     }


### PR DESCRIPTION
- re-authenticating, when a valid client side session exists, was causing the UI to hang at auth-callback
- this fixes that by side-stepping the authenticator if there's a client-side session and a valid server-side session
- this also ensures that validating client-side session data is matched against the server-side session

Addresses: https://github.com/eclipse-pass/main/issues/379