### PR TITLE
Snapshot versions should build dev images

### DIFF
--- a/.github/actions/build-pass-ui/action.yml
+++ b/.github/actions/build-pass-ui/action.yml
@@ -7,6 +7,10 @@ inputs:
   env-file:
     description: 'URL location of .env file. Default is the .env file in "eclipse-pass/main"'
     default: 'https://raw.githubusercontent.com/eclipse-pass/pass-docker/main/.env'
+  is-prod:
+    description: Will this target production?
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -20,7 +24,14 @@ runs:
     - run: yarn install --frozen-lockfile
       shell: bash
 
-    - run: yarn run build
+    - name: Production build
+      run: yarn run build
+      if: ${{ inputs.is-prod }}
+      shell: bash
+
+    - name: Dev build
+      if: ${{ !inputs.is-prod}}
+      run: yarn run build:dev
       shell: bash
 
     - run: yarn run build:docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Build pass-ui
         uses: ./.github/actions/build-pass-ui
+        with:
+          is-prod: true
 
       - name: Login to GHCR
         uses: docker/login-action@v2
@@ -59,6 +61,11 @@ jobs:
 
       - name: Update project version
         run: yarn version --new-version ${{ inputs.nextversion }}
+
+      - name: Build next dev version
+        uses: ./.github/actions/build-pass-ui
+        with:
+          is-prod: false
 
       # Commits made to branch specified in workflow_dispatch, push that branch if possible
       - name: Push release commits to GH

--- a/build.sh
+++ b/build.sh
@@ -23,3 +23,7 @@ rm -rf dist/
 yarn install --frozen-lockfile
 yarn run build:dev
 yarn run build:latest
+
+# For unambiguous naming to be used in local dev docker-compose env
+# Do not push this tag
+docker tag ghcr.io/eclipse-pass/pass-ui:latest ui-local


### PR DESCRIPTION
"Build" action can be told to build dev or prod artifacts. Dev build is default behavior, Release workflow updated to make "prod" image for full release, but dev version for any -snapshots