### PR TITLE
Workaround error exporting .env file

### DIFF
--- a/.github/actions/build-pass-ui/action.yml
+++ b/.github/actions/build-pass-ui/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Grab pass-docker's .env file and export to environment
       run: |
         wget ${{ inputs.env-file }}
-        export $(grep -v '^[#|SIGNING]' .env | xargs -d '\n')
+        export $(grep -v '^[#|SIGNING|PASS_CORE_POLICY]' .env | xargs -d '\n')
       shell: bash
 
     - run: yarn install --frozen-lockfile

--- a/build.sh
+++ b/build.sh
@@ -13,9 +13,9 @@ fi
 # Ignore any SIGNING_CERT* variables
 unamestr=$(uname)
 if [ "$unamestr" = 'Linux' ]; then
-  export $(grep -v '^[#|SIGNING]' $ENV_FILE | xargs -d '\n')
+  export $(grep -v '^[#|SIGNING|PASS_CORE_POLICY]' $ENV_FILE | xargs -d '\n')
 elif [ "$unamestr" = 'FreeBSD' ] || [ "$unamestr" = 'Darwin' ]; then
-  export $(grep -v '^[#|SIGNING]' $ENV_FILE | xargs -0)
+  export $(grep -v '^[#|SIGNING|PASS_CORE_POLICY]' $ENV_FILE | xargs -0)
 fi
 
 rm -rf dist/


### PR DESCRIPTION
Will ignore the newish env vars from pass-docker that start with PASS_CORE_POLICY. They are not used by pass-ui, so not needed during the build