### PR TITLE
fix: fix flash messages

### DIFF
--- a/app/components/workflow-review/index.hbs
+++ b/app/components/workflow-review/index.hbs
@@ -1,19 +1,17 @@
 {{! template-lint-disable no-action no-inline-styles no-unknown-arguments-for-builtin-components require-button-type require-input-label }}
 <div class="form-group row" {{did-insert this.initializeTooltip}}>
-  {{#if this.isTest}}
-    {{#each this.flashMessages.queue as |flash|}}
-      <div class="flash-message-container">
-        <FlashMessage @flash={{flash}} as |component flash close|>
-          <div class="d-flex justify-content-between">
-            {{flash.message}}
-            <span role="button" {{on "click" close}}>
-              x
-            </span>
-          </div>
-        </FlashMessage>
-      </div>
-    {{/each}}
-  {{/if}}
+  {{#each this.flashMessages.queue as |flash|}}
+    <div class="flash-message-container">
+      <FlashMessage @flash={{flash}} as |component flash close|>
+        <div class="d-flex justify-content-between">
+          {{flash.message}}
+          <span role="button" {{on "click" close}}>
+            x
+          </span>
+        </div>
+      </FlashMessage>
+    </div>
+  {{/each}}
   <div class="col-md-12">
     <div class="list-group">
       <div href="#" class="list-group-item flex-column align-items-start">

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -101,15 +101,22 @@ export default class SubmissionsNew extends Controller {
 
       await get(this, 'submissionHandler.submit')
         .perform(sub, pub, files, comment)
+        .then(() => {
+          set(this, 'uploading', false);
+          set(this, 'comment', '');
+          set(this, 'workflow.filesTemp', A());
+          this.transitionToRoute('thanks', { queryParams: { submission: get(sub, 'id') } });
+        })
         .catch((error) => {
           this.set('uploading', false);
-          this.flashMessages.error(`Submission failed: ${error.message}`);
-        });
 
-      set(this, 'uploading', false);
-      set(this, 'comment', '');
-      set(this, 'workflow.filesTemp', A());
-      this.transitionToRoute('thanks', { queryParams: { submission: get(sub, 'id') } });
+          this.flashMessages.danger(`Submission failed: ${error.message}`);
+
+          const elements = document.querySelectorAll('.block-user-input');
+          elements.forEach((el) => {
+            el.style.display = 'none';
+          });
+        });
     }
   }
 


### PR DESCRIPTION
- our catch block for the submission review step was previously not being hit
- a new issue with submissions exposed that we were calling an invalid method on `this.flashMessages` (i.e. `error` instead of `danger`).
- this addresses that issue