### PR TITLE
fix: enable prod builds

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -38,7 +38,10 @@ module.exports = function (defaults) {
       },
     },
     fingerprint: {
-      exclude: ['branding.css', 'error-icon.png', 'fullSizeLogo.png'],
+      enabled: false,
+    },
+    'ember-test-selectors': {
+      strip: false,
     },
   });
 


### PR DESCRIPTION
- we need to not fingerprint assets for now or it will break the theme'ing (we'll fix that later)
- we also need to not strip the data test selectors because test cafe relies on them