### PR TITLE
Allow workflows to call this release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ on:
       nextversion:
         required: true
         description: Next development version (e.g. 0.5.0-SNAPSHOT)
+  workflow_call:
+    inputs:
+      releaseversion:
+        required: true
+        description: Version to release (e.g. 0.4.0)
+        type: string
+      nextversion:
+        required: true
+        description: Next development version (e.g. 0.5.0-SNAPSHOT)
+        type: string
 
 jobs:
   release:


### PR DESCRIPTION
Needed if we consolidate releases into a single workflow in `eclipse-pass/main`, would be called like: https://github.com/eclipse-pass/main/blob/80a99993637d93708ff354c28844ea78ced54b82/.github/workflows/release.yml#L33-L37