### PR TITLE
fix: toggle optional repo

### DIFF
--- a/app/components/repository-card/index.js
+++ b/app/components/repository-card/index.js
@@ -4,8 +4,6 @@ import { action } from '@ember/object';
 export default class RepositoryCard extends Component {
   @action
   toggle(event) {
-    event.preventDefault();
-
     const repo = this.args.repository;
     const type = this.type;
     const selected = event.target.checked;

--- a/tests/integration/components/workflow-repositories-test.js
+++ b/tests/integration/components/workflow-repositories-test.js
@@ -161,11 +161,14 @@ module('Integration | Component | workflow repositories', (hooks) => {
     const checkboxes = this.element.querySelectorAll('input[type="checkbox"]');
     assert.strictEqual(checkboxes.length, 3, 'Unexpected number of checkboxes found');
 
+    assert.dom(checkboxes[2]).isNotChecked();
+
     await click(checkboxes[2]);
 
     assert.strictEqual(repos.length, 3, 'unexpected number of repositories attached to submission');
     assert.ok(repos.isAny('name', 'Moo-pository 00'));
     assert.notOk(repos.includes(undefined), 'there should be no "undefined" entries');
+    assert.dom(checkboxes[2]).isChecked();
   });
 
   test('Unselecting optional repo removes it from submission', async function (assert) {
@@ -201,10 +204,13 @@ module('Integration | Component | workflow repositories', (hooks) => {
     const checkboxes = this.element.querySelectorAll('input[type="checkbox"]');
     assert.strictEqual(checkboxes.length, 3, 'unexpected number of checkboxes found');
 
+    assert.dom(checkboxes[2]).isChecked();
+
     await click(checkboxes[2]);
 
     assert.strictEqual(repos.length, 2, 'unexpected number of repositories attached to the submission');
     assert.notOk(repos.isAny('name', 'Moo-pository 00'));
+    assert.dom(checkboxes[2]).isNotChecked();
   });
 
   /**


### PR DESCRIPTION
- checking/unchecking the optional repo on the repositories step was not working
- this removes preventDefault which was interfering with the native browser interaction
- this adds assertions to tests in this area that weren't previously covered
- partially resolves https://github.com/eclipse-pass/main/issues/656