### PR TITLE
fix: submission index manuscript id loads

### DIFF
--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -15,6 +15,7 @@ export default class IndexRoute extends CheckSessionRoute {
     if (user.isAdmin) {
       query = {
         filter: { submission: 'submissionStatus=out=cancelled' },
+        include: 'publication',
       };
     } else if (user.isSubmitter) {
       const userMatch = `submitter.id==${user.id},preparers.id=in=${user.id}`;
@@ -23,6 +24,7 @@ export default class IndexRoute extends CheckSessionRoute {
           submission: `(${userMatch});submissionStatus=out=cancelled`,
         },
         sort: '-submittedDate',
+        include: 'publication',
       };
     }
 


### PR DESCRIPTION
- in order to display manuscript IDs on a fresh load of the submissions index page we need publications to be loaded as well
- this includes publications with the submissions fetch
- partially addresses: https://github.com/eclipse-pass/main/issues/656