### PR TITLE
fix: edit submission bug re missing doiInfo

### DIFF
--- a/app/components/workflow-basics/index.js
+++ b/app/components/workflow-basics/index.js
@@ -106,7 +106,7 @@ export default class WorkflowBasics extends Component {
      * Only do this if there is no publication DOI, as the DOI lookup will cover this case.
      */
     if (!get(this, 'publication.doi') && this.journal) {
-      this.selectJournal(this.journal);
+      scheduleOnce('afterRender', this, 'selectJournal', this.journal);
     }
   }
 


### PR DESCRIPTION
- when editing a submission we call selectJournal which calls updateDoi during the render cycle causing the bug
- this uses scheduleOnce afterRender to fix that

Closes: https://github.com/eclipse-pass/main/issues/691