### PR TITLE
fix: proxy submission card colors are conflicting with branding

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -229,6 +229,16 @@ td {
   color: white;
 }
 
+/* Submission workflow */
+#proxy-input-block {
+  background-color: #f0f3f5;
+  color: black;
+}
+#on-behalf-of-block {
+  background-color: #f0f3f5;
+  color: black;
+}
+
 .back-arrow {
   margin: 0px;
   padding: 1px !important;

--- a/public/branding.css
+++ b/public/branding.css
@@ -145,12 +145,11 @@ a:hover,
 }
 .submissions-detail-comment-textarea {
   resize: none;
-  min-height: 38px!important;
+  min-height: 38px !important;
 }
 .table-container {
   overflow-x: auto;
 }
-
 
 /* Status icons */
 .manuscript-required > .fa-circle,
@@ -184,16 +183,6 @@ a:hover,
 .draft > .fa-circle,
 .draft .fa-info-circle {
   color: gray;
-}
-
-/* Submission workflow */
-#proxy-input-block {
-  background-color: var(--secondary-500);
-  color: white;
-}
-#on-behalf-of-block {
-  background-color: var(--secondary-500);
-  color: white;
 }
 
 th.table-header > i {


### PR DESCRIPTION
- this makes the proxy sub card background the same as the steps background and the font black
- this should make the links visible and allow most branding to have links to emails that will pass accessibility tests

Closes: https://github.com/eclipse-pass/main/issues/693

![Screenshot 2023-08-24 at 10 34 58 AM](https://github.com/eclipse-pass/pass-ui/assets/6305935/41abd30e-4dbf-4764-8caf-925232eada7c)
