### PR TITLE
[pass-ui] Submission and Deposit optimistic locking

### DIFF
--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -18,6 +18,7 @@ export default class SubmissionModel extends Model {
     defaultValue: null,
   })
   submitterEmail;
+  @attr('number') version;
 
   @belongsTo('user') submitter;
   @belongsTo('publication') publication;

--- a/tests/unit/services/submission-handler-test.js
+++ b/tests/unit/services/submission-handler-test.js
@@ -40,6 +40,7 @@ module('Unit | Service | submission-handler', (hooks) => {
 
     let submission = EmberObject.create({
       id: '0',
+      version: 3,
       submitter: {
         id: 'submitter:test-id',
       },
@@ -62,7 +63,7 @@ module('Unit | Service | submission-handler', (hooks) => {
     let files = A();
     let comment = 'blarg';
 
-    assert.expect(13);
+    assert.expect(14);
 
     return service
       .get('submit')
@@ -70,6 +71,7 @@ module('Unit | Service | submission-handler', (hooks) => {
       .then(() => {
         assert.false(submission.get('submitted'));
         assert.strictEqual(submission.get('submissionStatus'), 'approval-requested');
+        assert.strictEqual(submission.get('version'), 3);
 
         // web-link repo should not be removed
         assert.strictEqual(submission.get('repositories.length'), 2);


### PR DESCRIPTION
This is support optimistic locking with Submission/Deposit.  I didn't add the `version` attribute to Deposit because it doesn't appear Deposits are saved from the UI.

https://github.com/eclipse-pass/main/issues/715