### PR TITLE
fix: metadata step glyphs

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -282,16 +282,16 @@ td {
   font-style: normal;
 }
 .glyphicon-plus-sign:before {
-  content: '\f067';
+  content: '+';
 }
 .glyphicon-minus-sign:before {
-  content: '\f068';
+  content: '–';
 }
 .glyphicon-chevron-up:before {
-  content: '\f077';
+  content: '\22c0';
 }
 .glyphicon-chevron-down:before {
-  content: '\f078';
+  content: '\22c1';
 }
 .glyphicon-info-sign:before {
   content: '\f05a';


### PR DESCRIPTION
Closes: https://github.com/eclipse-pass/main/issues/704
Closes: https://github.com/eclipse-pass/main/issues/705

For some unknown reason the FontAwesome glyphs aren't rendering any more. This moves to using unicode chars instead.

![Screenshot 2023-09-20 at 10 53 32 AM](https://github.com/eclipse-pass/pass-ui/assets/6305935/29cfc37e-fe74-4b03-90b1-d4300f9db65f)
![Screenshot 2023-09-20 at 10 53 29 AM](https://github.com/eclipse-pass/pass-ui/assets/6305935/48d2d647-05c4-4d66-8496-eff2a4191adf)

