### PR TITLE
fix: add submission methods back to journal

### DIFF
--- a/app/models/journal.js
+++ b/app/models/journal.js
@@ -1,6 +1,22 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes */
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
+
+/**
+ * Publisher participation in NIH Public Access Program by sending final published article to PMC.
+ *
+ * Possible values:
+ *   - A (Route A: journal automatically post paper to PMC)
+ *   - B (Route B: authors must make special arrangements for some journals and publishers to post the paper directly to PMC)
+ *   - C (Route C: authors or deignee must submit manuscripts to NIHMS)
+ *   - D (Route D: some publishers will submit manuscripts to NIHMS)
+ */
+const PMCParticipation = {
+  A: 'A',
+  B: 'B',
+  C: 'C',
+  D: 'D',
+};
 
 export default class JournalModel extends Model {
   /**


### PR DESCRIPTION
- they were removed inadvertently when we removed publisher