### PR TITLE
Externalize instructions Url to config.json

### DIFF
--- a/app/components/notice-banner/index.hbs
+++ b/app/components/notice-banner/index.hbs
@@ -1,16 +1,12 @@
 {{#if this.displayInfoBanner}}
   <div class="info-banner p-1 text-center font-weight-bold">
     Need help making a submission? Read our submission workflow
-    <a
-      href="https://github.com/eclipse-pass/main/blob/main/docs/user/README.md"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <a class="instructions-url" href={{this.instructionsUrl}} target="_blank" rel="noopener noreferrer">
       instructions
     </a>
     {{#if this.contactUrl}}
       or
-      <a href={{this.contactUrl}} target="_blank" rel="noopener noreferrer">
+      <a class="contact-us-url" href={{this.contactUrl}} target="_blank" rel="noopener noreferrer">
         contact us
       </a>
     {{/if}}

--- a/app/components/notice-banner/index.js
+++ b/app/components/notice-banner/index.js
@@ -1,12 +1,28 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes */
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency-decorators';
 
 export default class NoticeBanner extends Component {
   @service router;
+  @service appStaticConfig;
+  @tracked contactUrl = null;
+  @tracked instructionsUrl = null;
+
+  constructor() {
+    super(...arguments);
+    this._setupAppStaticConfig.perform();
+  }
 
   get displayInfoBanner() {
     return true;
   }
+
+  @task
+  _setupAppStaticConfig = function* () {
+    let config = yield this.appStaticConfig.getStaticConfig();
+    this.contactUrl = config.branding.pages.contactUrl;
+    this.instructionsUrl = config.branding.pages.instructionsUrl;
+  };
 }

--- a/tests/integration/components/notice-banner-test.js
+++ b/tests/integration/components/notice-banner-test.js
@@ -1,0 +1,40 @@
+/* eslint-disable ember/no-classic-classes */
+import Service from '@ember/service';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | notice-banner', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    const mockStaticConfig = Service.extend({
+      getStaticConfig: () =>
+        Promise.resolve({
+          branding: {
+            stylesheet: '',
+            pages: {
+              contactUrl: 'http://test-contact/',
+              instructionsUrl: 'http://test-instructions/',
+            },
+          },
+        }),
+      addCss: () => {},
+    });
+
+    this.owner.register('service:app-static-config', mockStaticConfig);
+
+    await render(hbs`<NoticeBanner />`);
+    assert.equal(
+      this.element.querySelector('.instructions-url').getAttribute('href'),
+      'http://test-instructions/',
+      'instruction url populated'
+    );
+    assert.equal(
+      this.element.querySelector('.contact-us-url').getAttribute('href'),
+      'http://test-contact/',
+      'contact us url populated'
+    );
+  });
+});


### PR DESCRIPTION
This PR externalizes the instruction URL in the notice banner to the config.json so it can vary by env.

https://github.com/eclipse-pass/main/issues/690