### PR TITLE
Call user service with a userToken parameter

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -15,10 +15,8 @@ export default class ApplicationController extends Controller {
   @alias('model.staticConfig')
   staticConfig;
 
-  params = ['userToken'];
   rootURL = config.rootURL;
 
-  @tracked userToken = null;
   @tracked wideRoutes = ['grants.index', 'grants.detail', 'submissions.index'];
   @tracked brand = get(this, 'staticConfig.branding');
   @tracked currentRouteName = this.router.currentRouteName;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -6,6 +6,8 @@ import { action } from '@ember/object';
 export default class ApplicationRoute extends CheckSessionRoute {
   @service('app-static-config') staticConfig;
 
+  queryParams = ['userToken'];
+
   /* Used as route-action in templates */
   @action
   back() {
@@ -18,42 +20,14 @@ export default class ApplicationRoute extends CheckSessionRoute {
   }
 
   /**
-   * It is possible for unfortunate things to happen somewhere in the backend stack
-   * that will result in route ids not being encoded.
-   * Therefore we specially handle the /submissions/id and /grants/id routes. In
-   * the event that unencoded ID is encountered (it will include slashes), replace
-   * the current history with the encoded version.
+   * If there is a userToken query parameter call the user service with that parameter
+   * to ensure objects are updated in the backend before any queries are done.
    */
   beforeModel(transition) {
-    let intent = transition.intent.url;
+    let userToken = transition.to.queryParams.userToken;
 
-    if (!intent) {
-      return;
-    }
-
-    let prefix = null;
-
-    if (intent.startsWith('/grants/')) {
-      prefix = '/grants/';
-    } else if (intent.startsWith('/submissions/')) {
-      prefix = '/submissions/';
-    } else {
-      return;
-    }
-
-    // Work around ember collapsing // into /
-    if (intent.includes('https:/') && !intent.includes('https://')) {
-      intent = intent.replace('https:/', 'https://');
-    }
-
-    // Ensure that route parameter is encoded
-    if (intent.includes('https://')) {
-      let q = intent.indexOf('?');
-      if (q == -1) {
-        q = intent.length;
-      }
-      const targetId = intent.substring(prefix.length, q);
-      this.replaceWith(intent.replace(targetId, `${encodeURIComponent(targetId)}`));
+    if (userToken) {
+      return fetch(`/user/whoami?userToken=${encodeURIComponent(userToken)}`);
     }
   }
 


### PR DESCRIPTION
Makes sure the user service gets called once if the userToken parameter is provided before everything else. The service may modify submission objects in the backend.

This also removes the weird route munging which was needed because of proxy url encoding issues and is no longer needed. 