### PR TITLE
Correctly handle whitespace when normalizing proxy user queries

### DIFF
--- a/app/components/workflow-basics-user-search/index.js
+++ b/app/components/workflow-basics-user-search/index.js
@@ -49,7 +49,8 @@ export default class WorkflowBasicsUserSearch extends Component {
   @task
   searchForUsers = function* (page) {
     // Strip out non-alphanumberic characters to ensure filter is valid
-    let input = this.args.searchInput.replace(/\W/g, '');
+    // Such characters in the middle of the string become a space
+    let input = this.args.searchInput.replace(/\W+/g, ' ').trim();
 
     if (input.length == 0) {
       return;


### PR DESCRIPTION
Now multiple non-alphanumeric characters in the search string become a single space. In addition space is trimmed off the ends of the string. So now searching for "Mark+=Patton" and "Mark Patton" and "  Mark   Patton " will all be normalized to "Mark Patton".