### PR TITLE
fix: remove link in header from from policies cards

### DIFF
--- a/app/components/policy-card/index.hbs
+++ b/app/components/policy-card/index.hbs
@@ -2,9 +2,7 @@
 <div class="card w-100 my-2" {{did-insert this.setup}}>
   <div class="card-body">
     <h4 class="card-title" data-test-policy-title>
-      <a href="#">
-        {{@policy.title}}
-      </a>
+      {{@policy.title}}
     </h4>
     {{#if this.policyIsJHU}}
       <h6 class="card-subtitle mb-2" data-test-jhu-policy-deposit-expectation>


### PR DESCRIPTION
Closes: https://github.com/eclipse-pass/main/issues/772

![Screenshot_2023-10-17_at_2_09_47_PM](https://github.com/eclipse-pass/pass-ui/assets/6305935/7725cc38-a345-4fe2-a1b3-3ba717fb62e4)

