### PR TITLE
Fix bug displaying error message when doi lookup fails

### DIFF
--- a/app/components/workflow-basics/index.js
+++ b/app/components/workflow-basics/index.js
@@ -295,10 +295,10 @@ export default class WorkflowBasics extends Component {
       this.args.validateTitle();
       this.args.validateJournal();
     } catch (error) {
-      console.log(`DOI service request failed: ${error.payload.error}`);
+      console.log(`DOI service request failed: ${error}`);
 
       this.clearDoiData(this.publication.doi);
-      set(this, 'doiServiceError', error.payload.error);
+      set(this, 'doiServiceError', error);
       // eslint-disable-next-line newline-per-chained-call
     }
   };


### PR DESCRIPTION
If you paste in a valid doi and then just mess with it by adding  or deleting a character, you get an error popup. This is just caused by a bug handling the error message.