### PR TITLE
Adding server-side pagination support

### DIFF
--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -1,64 +1,137 @@
 /* eslint-disable ember/no-classic-classes */
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { hash } from 'rsvp';
 
-export default Controller.extend({
-  currentUser: service('current-user'),
-  themeInstance: service('emt-themes/bootstrap4'),
+export default class GrantDetailsController extends Controller {
+  @service('emt-themes/bootstrap4') themeInstance;
+  @service currentUser;
+  @service store;
 
-  grant: alias('model.grant'),
+  get grant() {
+    return this.model.grant;
+  }
 
   // Columns displayed depend on the user role
-  columns: computed('currentUser', {
-    get() {
-      return [
-        {
-          propertyName: 'publicationTitle',
-          className: 'title-column',
-          title: 'Article',
-          component: 'submissions-article-cell',
-        },
-        {
-          title: 'Award Number (Funder)',
-          propertyName: 'grantInfo',
-          className: 'awardnum-funder-column',
-          component: 'submissions-award-cell',
-          disableSorting: true,
-        },
-        {
-          propertyName: 'repositoryNames',
-          title: 'Repositories',
-          component: 'submissions-repo-cell',
-          className: 'repositories-column',
-          disableSorting: true,
-        },
-        {
-          propertyName: 'submittedDate',
-          title: 'Submitted Date',
-          className: 'date-column',
-          component: 'date-cell',
-        },
-        {
-          propertyName: 'submissionStatus',
-          title: 'Status',
-          className: 'status-column',
-          component: 'submissions-status-cell',
-        },
-        {
-          propertyName: 'repoCopies',
-          className: 'msid-column',
-          title: 'Manuscript IDs',
-          component: 'submissions-repoid-cell',
-          disableSorting: true,
-        },
-        {
-          title: 'Actions',
-          className: 'actions-column',
-          component: 'submission-action-cell',
-        },
-      ];
+  columns = [
+    {
+      propertyName: 'publicationTitle',
+      className: 'title-column',
+      title: 'Article',
+      component: 'submissions-article-cell',
     },
-  }),
-});
+    {
+      title: 'Award Number (Funder)',
+      propertyName: 'grantInfo',
+      className: 'awardnum-funder-column',
+      component: 'submissions-award-cell',
+      disableSorting: true,
+    },
+    {
+      propertyName: 'repositoryNames',
+      title: 'Repositories',
+      component: 'submissions-repo-cell',
+      className: 'repositories-column',
+      disableSorting: true,
+    },
+    {
+      propertyName: 'submittedDate',
+      title: 'Submitted Date',
+      className: 'date-column',
+      component: 'date-cell',
+    },
+    {
+      propertyName: 'submissionStatus',
+      title: 'Status',
+      className: 'status-column',
+      component: 'submissions-status-cell',
+    },
+    {
+      propertyName: 'repoCopies',
+      className: 'msid-column',
+      title: 'Manuscript IDs',
+      component: 'submissions-repoid-cell',
+      disableSorting: true,
+    },
+    {
+      title: 'Actions',
+      className: 'actions-column',
+      component: 'submission-action-cell',
+    },
+  ];
+
+  @tracked queuedModel;
+
+  queryParams = ['page', 'pageSize', 'filter'];
+
+  @tracked page;
+  @tracked pageSize = 10;
+  @tracked filter;
+
+  tablePageSizeValues = [10, 25, 50];
+  filterQueryParameters = {
+    pageSize: 'pageSize',
+    page: 'page',
+    globalFilter: 'filter',
+  };
+
+  get itemsCount() {
+    return this.queuedModel.submissions.meta?.page?.totalRecords;
+  }
+
+  get pagesCount() {
+    return this.queuedModel.submissions.meta?.page?.totalPages;
+  }
+
+  get submissionsQuery() {
+    /**
+     * TODO:
+     * TMP restriction - don't show submissions that are in DRAFT status
+     * unless you are the submitter OR preparer
+     * Show submissions where `submitted===true`, because they are no longer editable
+     */
+    const userId = this.currentUser.user.id;
+    const userMatch = `submitted==true,(submitter.id==${userId},preparers.id=in=${userId})`;
+    return {
+      filter: {
+        submission: `grants.id==${this.grant.id};submissionStatus=out=cancelled;(${userMatch})`,
+      },
+    };
+  }
+
+  @action
+  displayAction(display) {
+    this.page = display.currentPageNumber;
+    this.pageSize = display.pageSize;
+    this.filter = display.filterString;
+  }
+
+  @action
+  doQuery(params) {
+    const { page = 1, pageSize = 10 } = params;
+    let query = this.submissionsQuery;
+    query.page = {
+      number: page,
+      size: pageSize,
+      totals: true,
+    };
+
+    if (params.filter) {
+      query.filter.submission = `(${query.filter.submission});publication.title=ini=*${params.filter}*`;
+    }
+
+    let submissions = this.store.query('submission', query).then((data) => {
+      this.queuedModel = {
+        submissions: {
+          data,
+          meta: data.meta,
+        },
+      };
+    });
+
+    // Don't need to re-load the grant
+    return submissions;
+  }
+}

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -130,7 +130,7 @@ export default class GrantsIndexController extends Controller {
 
   @tracked page = 1;
   @tracked pageSize = 10;
-  tablePageSizeValues = [2, 5, 10, 25, 50]; // TODO: Make configurable?
+  tablePageSizeValues = [10, 25, 50]; // TODO: Make configurable?
   @tracked filter;
 
   filterQueryParameters = {

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -124,16 +124,17 @@ export default class GrantsIndexController extends Controller {
   @tracked messageText = '';
   @tracked user = this.currentUser.user;
 
-  queryParams = ['page', 'pageSize', 'globalSearch'];
+  queryParams = ['page', 'pageSize', 'filter'];
 
   @tracked page;
   @tracked pageSize;
   tablePageSizeValues = [10, 25, 50]; // TODO: Make configurable?
+  @tracked filter;
 
   filterQueryParameters = {
     pageSize: 'pageSize',
     page: 'page',
-    globalFilter: 'globalSearch',
+    globalFilter: 'filter',
   };
 
   // Columns displayed depend on the user role
@@ -159,7 +160,7 @@ export default class GrantsIndexController extends Controller {
   displayAction(display) {
     this.page = display.currentPageNumber;
     this.pageSize = display.pageSize;
-    this.globalSearch = display.filterString;
+    this.filter = display.filterString;
   }
 
   @action

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -229,7 +229,6 @@ export default class GrantsIndexController extends Controller {
       })
       .then((results) => {
         this.queuedModel = results;
-      })
-      .catch((e) => console.error(e));
+      });
   }
 }

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable ember/classic-decorator-no-classic-methods */
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
@@ -7,6 +8,7 @@ export default class GrantsIndexController extends Controller {
   @service currentUser;
   @service('app-static-config') configurator;
   @service('emt-themes/bootstrap4') themeInstance;
+  @service router;
 
   constructor() {
     super(...arguments);
@@ -120,9 +122,19 @@ export default class GrantsIndexController extends Controller {
   @tracked messageTo = '';
   @tracked messageSubject = '';
   @tracked messageText = '';
-  @tracked tablePageSize = 50;
-  @tracked tablePageSizeValues = [10, 25, 50];
   @tracked user = this.currentUser.user;
+
+  queryParams = ['page', 'pageSize', 'globalSearch'];
+
+  @tracked page;
+  @tracked pageSize;
+  tablePageSizeValues = [10, 25, 50]; // TODO: Make configurable?
+
+  filterQueryParameters = {
+    pageSize: 'pageSize',
+    page: 'page',
+    globalFilter: 'globalSearch',
+  };
 
   // Columns displayed depend on the user role
   get columns() {
@@ -133,5 +145,25 @@ export default class GrantsIndexController extends Controller {
     }
     console.warn(`[Route:Grants/index] User has no known role (${this.user.id}::${this.user.roles})`);
     return [];
+  }
+
+  get itemsCount() {
+    return this.model?.meta?.page?.totalRecords;
+  }
+
+  get pagesCount() {
+    return this.model?.meta?.page?.totalPages;
+  }
+
+  @action
+  displayAction(display) {
+    this.page = display.currentPageNumber;
+    this.pageSize = display.pageSize;
+    this.globalSearch = display.filterString;
+  }
+
+  @action
+  doQuery(query) {
+    return this.router.transitionTo({ queryParams: { ...query } });
   }
 }

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -182,16 +182,11 @@ export default class SubmissionsIndex extends Controller {
       query.filter.submission = `(${query.filter.submission});publication.title=ini=*${params.filter}*`;
     }
 
-    return this.store
-      .query('submission', query)
-      .then((data) => {
-        this.queuedModel = {
-          submissions: data,
-          meta: data.meta,
-        };
-      })
-      .catch((e) => {
-        console.error(e);
-      });
+    return this.store.query('submission', query).then((data) => {
+      this.queuedModel = {
+        submissions: data,
+        meta: data.meta,
+      };
+    });
   }
 }

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -25,7 +25,7 @@ export default class SubmissionsIndex extends Controller {
 
   @tracked page;
   @tracked pageSize;
-  tablePageSizeValues = [1, 5, 10, 25, 50]; // TODO: Make configurable?
+  tablePageSizeValues = [10, 25, 50]; // TODO: Make configurable?
   @tracked filter;
 
   filterQueryParameters = {

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -1,30 +1,20 @@
 import { service } from '@ember/service';
 import CheckSessionRoute from '../check-session-route';
-import RSVP from 'rsvp';
-import { restartableTask, timeout } from 'ember-concurrency';
 
-const DEBOUNCE_MS = 500;
 export default class IndexRoute extends CheckSessionRoute {
   @service('current-user') currentUser;
   @service store;
 
   queryParams = {
-    page: { refreshModel: true },
-    pageSize: { refreshModel: true },
-    filter: { refreshModel: true },
+    page: {},
+    pageSize: {},
+    filter: {},
   };
 
   async model(params) {
-    return RSVP.hash({
-      submissions: this.getSubmissions.perform(this.currentUser.user, params),
-    });
-  }
-
-  @restartableTask
-  getSubmissions = function* (user, params) {
-    yield timeout(DEBOUNCE_MS);
-
     let query;
+
+    const user = this.currentUser.user;
 
     if (user.isAdmin) {
       query = {
@@ -53,6 +43,14 @@ export default class IndexRoute extends CheckSessionRoute {
       query.filter.submission = `(${query.filter.submission});publication.title=ini=*${params.filter}*`;
     }
 
-    return this.store.query('submission', query);
-  };
+    return this.store.query('submission', query).then((data) => ({
+      submissions: data,
+      meta: data.meta,
+    }));
+  }
+
+  setupController(controller, model) {
+    super.setupController(...arguments);
+    controller.queuedModel = model;
+  }
 }

--- a/app/templates/grants/detail.hbs
+++ b/app/templates/grants/detail.hbs
@@ -84,8 +84,8 @@
       Submissions for grant
     </h3>
     <div class="submission-table">
-      <ModelsTable
-        @data={{this.model.submissions}}
+      <ModelsTableServerPaginated
+        @data={{this.queuedModel.submissions.data}}
         @columns={{this.columns}}
         @themeInstance={{this.themeInstance}}
         @showColumnsDropdown={{false}}
@@ -93,6 +93,15 @@
         @multipleColumnsSorting={{false}}
         @useFilteringByColumns={{false}}
         @showGlobalFilter={{false}}
+        @pageSize={{this.pageSize}}
+        @pageSizeValues={{this.tablePageSizeValues}}
+        @currentPageNumber={{this.page}}
+        @itemsCount={{this.itemsCount}}
+        @pagesCount={{this.pagesCount}}
+        @filterString={{this.filter}}
+        @filterQueryParameters={{this.filterQueryParameters}}
+        @doQuery={{this.doQuery}}
+        @onDisplayDataChanged={{this.displayAction}}
       />
     </div>
   </div>

--- a/app/templates/grants/index.hbs
+++ b/app/templates/grants/index.hbs
@@ -30,6 +30,7 @@
         @pageSizeValues={{this.tablePageSizeValues}}
         @itemsCount={{this.itemsCount}}
         @pagesCount={{this.pagesCount}}
+        @filterString={{this.filter}}
         @filterQueryParameters={{this.filterQueryParameters}}
         @doQuery={{this.doQuery}}
         @onDisplayDataChanged={{this.displayAction}}

--- a/app/templates/grants/index.hbs
+++ b/app/templates/grants/index.hbs
@@ -17,17 +17,22 @@
 <div class="row justify-content-center grant-table">
   <div class="col-12 table-container">
     <div class="grant-table">
-      <ModelsTable
-        @data={{this.model}}
+      <ModelsTableServerPaginated
+        @data={{this.model.grantMap}}
         @columns={{this.columns}}
         @themeInstance={{this.themeInstance}}
         @showColumnsDropdown={{false}}
         @useFilteringByColumns={{false}}
         @filteringIgnoreCase={{true}}
         @multipleColumnsSorting={{false}}
-        @piSelected="piclick"
-        @pageSize={{this.tablePageSize}}
+        @currentPageNumber={{this.page}}
+        @pageSize={{this.model.meta.page.limit}}
         @pageSizeValues={{this.tablePageSizeValues}}
+        @itemsCount={{this.itemsCount}}
+        @pagesCount={{this.pagesCount}}
+        @filterQueryParameters={{this.filterQueryParameters}}
+        @doQuery={{this.doQuery}}
+        @onDisplayDataChanged={{this.displayAction}}
       />
     </div>
   </div>

--- a/app/templates/grants/index.hbs
+++ b/app/templates/grants/index.hbs
@@ -18,7 +18,7 @@
   <div class="col-12 table-container">
     <div class="grant-table">
       <ModelsTableServerPaginated
-        @data={{this.model.grantMap}}
+        @data={{this.queuedModel.grantMap}}
         @columns={{this.columns}}
         @themeInstance={{this.themeInstance}}
         @showColumnsDropdown={{false}}
@@ -26,7 +26,7 @@
         @filteringIgnoreCase={{true}}
         @multipleColumnsSorting={{false}}
         @currentPageNumber={{this.page}}
-        @pageSize={{this.model.meta.page.limit}}
+        @pageSize={{this.pageSize}}
         @pageSizeValues={{this.tablePageSizeValues}}
         @itemsCount={{this.itemsCount}}
         @pagesCount={{this.pagesCount}}

--- a/app/templates/submissions/index.hbs
+++ b/app/templates/submissions/index.hbs
@@ -25,7 +25,7 @@
   <div class="col-12 table-container">
     <div class="submission-table" data-test-submissions-index-submissions-table>
       <ModelsTableServerPaginated
-        @data={{this.model.submissions}}
+        @data={{this.queuedModel.submissions}}
         @columns={{this.columns}}
         @themeInstance={{this.themeInstance}}
         @showColumnsDropdown={{false}}
@@ -33,7 +33,7 @@
         @filteringIgnoreCase={{true}}
         @multipleColumnsSorting={{false}}
         @authorSelected="authorclick"
-        @pageSize={{this.model.submissions.meta.page.limit}}
+        @pageSize={{this.pageSize}}
         @pageSizeValues={{this.tablePageSizeValues}}
         @currentPageNumber={{this.page}}
         @itemsCount={{this.itemsCount}}

--- a/app/templates/submissions/index.hbs
+++ b/app/templates/submissions/index.hbs
@@ -24,7 +24,7 @@
 <div class="row">
   <div class="col-12 table-container">
     <div class="submission-table" data-test-submissions-index-submissions-table>
-      <ModelsTable
+      <ModelsTableServerPaginated
         @data={{this.model.submissions}}
         @columns={{this.columns}}
         @themeInstance={{this.themeInstance}}
@@ -33,8 +33,15 @@
         @filteringIgnoreCase={{true}}
         @multipleColumnsSorting={{false}}
         @authorSelected="authorclick"
-        @pageSize={{this.tablePageSize}}
+        @pageSize={{this.model.submissions.meta.page.limit}}
         @pageSizeValues={{this.tablePageSizeValues}}
+        @currentPageNumber={{this.page}}
+        @itemsCount={{this.itemsCount}}
+        @pagesCount={{this.pagesCount}}
+        @filterString={{this.filter}}
+        @filterQueryParameters={{this.filterQueryParameters}}
+        @doQuery={{this.doQuery}}
+        @onDisplayDataChanged={{this.displayAction}}
       />
     </div>
   </div>

--- a/app/util/paginated-query.js
+++ b/app/util/paginated-query.js
@@ -1,0 +1,106 @@
+/**
+ * Paginated query for the submissions/index route
+ *
+ * @param {object} params url query params
+ * @param {User} user current user
+ */
+export function submissionsIndexQuery(params, user) {
+  let query;
+
+  if (user.isAdmin) {
+    query = {
+      filter: { submission: 'submissionStatus=out=cancelled' },
+      include: 'publication',
+    };
+  } else if (user.isSubmitter) {
+    const userMatch = `submitter.id==${user.id},preparers.id=in=${user.id}`;
+    query = {
+      filter: {
+        submission: `(${userMatch});submissionStatus=out=cancelled`,
+      },
+      sort: '-submittedDate',
+      include: 'publication',
+    };
+  }
+
+  const { page = 1, pageSize = 10 } = params;
+  query.page = {
+    number: page,
+    size: pageSize,
+    totals: true,
+  };
+
+  if (params.filter) {
+    query.filter.submission = `(${query.filter.submission});publication.title=ini=*${params.filter}*`;
+  }
+
+  return query;
+}
+
+/**
+ * Paginated query for the grant details page, querying for submissions associated
+ * with the given grant
+ *
+ * @param {object} params url query params. MUST include `grant_id` from the URL path
+ * @param {string} grantId ID for the Grant
+ * @param {User} user current user
+ */
+export function grantDetailsQuery(params, grantId, user) {
+  /**
+   * TODO: TMP restriction - don't show submissions that are in DRAFT status
+   * unless you are the submitter OR preparer
+   * Show submissions where `submitted===true`, because they are no longer editable
+   */
+  const userMatch = `submitted==true,(submitter.id==${user.id},preparers.id=in=${user.id})`;
+  const query = {
+    filter: {
+      submission: `grants.id==${grantId};submissionStatus=out=cancelled;(${userMatch})`,
+    },
+  };
+
+  const { page = 1, pageSize = 10 } = params;
+  query.page = {
+    number: page,
+    size: pageSize,
+    totals: true,
+  };
+
+  if (params.filter) {
+    query.filter.submission = `(${query.filter.submission});publication.title=ini=*${params.filter}*`;
+  }
+
+  return query;
+}
+
+export function grantsIndexGrantQuery(params, user) {
+  const userId = user.id;
+  // default values provided to force these params in the request to the backend
+  // TODO: make default pageSize configurable
+  const { page = 1, pageSize = 10 } = params;
+  const grantQuery = {
+    filter: {
+      grant: `pi.id==${userId},coPis.id==${userId}`,
+    },
+    sort: '+awardStatus,-endDate',
+    page: {
+      number: page,
+      size: pageSize,
+      totals: true,
+    },
+  };
+
+  if (params.filter) {
+    grantQuery.filter.grant = `(${grantQuery.filter.grant});projectName=ini=*${params.filter}*`;
+  }
+
+  return grantQuery;
+}
+
+export function grantsIndexSubmissionQuery(user) {
+  const userMatch = `grants.pi.id==${user.id},grants.coPis.id==${user.id}`;
+  return {
+    filter: {
+      submission: `submissionStatus=out=cancelled;(${userMatch})`,
+    },
+  };
+}

--- a/app/util/paginated-query.js
+++ b/app/util/paginated-query.js
@@ -31,7 +31,7 @@ export function submissionsIndexQuery(params, user) {
   };
 
   if (params.filter) {
-    query.filter.submission = `(${query.filter.submission});publication.title=ini=*${params.filter}*`;
+    query.filter.submission = `${query.filter.submission};${filter(params.filter, 'publication.title')}`;
   }
 
   return query;
@@ -58,16 +58,16 @@ export function grantDetailsQuery(params, grantId, user) {
     },
   };
 
+  if (params.filter) {
+    query.filter.submission = `(${query.filter.submission});${filter(params.filter, 'publication.title')}`;
+  }
+
   const { page = 1, pageSize = 10 } = params;
   query.page = {
     number: page,
     size: pageSize,
     totals: true,
   };
-
-  if (params.filter) {
-    query.filter.submission = `(${query.filter.submission});publication.title=ini=*${params.filter}*`;
-  }
 
   return query;
 }
@@ -90,7 +90,7 @@ export function grantsIndexGrantQuery(params, user) {
   };
 
   if (params.filter) {
-    grantQuery.filter.grant = `(${grantQuery.filter.grant});projectName=ini=*${params.filter}*`;
+    grantQuery.filter.grant = `(${grantQuery.filter.grant});${filter(params.filter, 'projectName')}`;
   }
 
   return grantQuery;
@@ -103,4 +103,23 @@ export function grantsIndexSubmissionQuery(user) {
       submission: `submissionStatus=out=cancelled;(${userMatch})`,
     },
   };
+}
+
+function filter(value, ...props) {
+  if (!value) {
+    return '';
+  }
+  return `(${props.map((prop) => `${prop}=ini=${filterValue(value)}`).join(',')})`;
+}
+
+/**
+ * @param {string} value
+ * @returns value surrounded by quotes if necessary
+ */
+function filterValue(value) {
+  value = value.trim();
+  if (value.search(/\s+/) >= 0) {
+    return `"*${value}*"`;
+  }
+  return `*${value}*`;
 }

--- a/tests/acceptance/nih-submission-test.js
+++ b/tests/acceptance/nih-submission-test.js
@@ -156,7 +156,7 @@ module('Acceptance | submission', function (hooks) {
     assert.ok(currentURL().includes('/thanks'));
 
     await click('[data-test-workflow-thanks-link-to-submissions]');
-    assert.strictEqual(currentURL(), '/submissions');
+    assert.ok(currentURL().startsWith('/submissions'));
 
     const submissionHref = '/submissions/2';
     await waitFor('[data-test-submissions-index-submissions-table]');
@@ -240,7 +240,8 @@ module('Acceptance | submission', function (hooks) {
     await click('[data-test-navbar-submissions-link]');
     await click('[data-test-navbar-submissions-link]');
 
-    assert.strictEqual(currentURL(), '/submissions');
+    // URL will probably have some paging params e.g. /submissions?page=1&pageSize=25
+    assert.ok(currentURL().startsWith('/submissions'));
 
     await waitFor('[data-test-submissions-index-submissions-table]');
 
@@ -353,7 +354,7 @@ module('Acceptance | submission', function (hooks) {
     assert.ok(currentURL().includes('/thanks'));
 
     await click('[data-test-workflow-thanks-link-to-submissions]');
-    assert.strictEqual(currentURL(), '/submissions');
+    assert.ok(currentURL().startsWith('/submissions'));
 
     await waitFor('[data-test-submissions-index-submissions-table]');
     await click(`${rowForSubmission} td a`);

--- a/tests/unit/controllers/grants/index-test.js
+++ b/tests/unit/controllers/grants/index-test.js
@@ -4,61 +4,82 @@ import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
+class MockConfigService extends Service {
+  getStaticConfig() {
+    return Promise.resolve({ branding: { stylesheet: '', pages: { faqUrl: '' } } });
+  }
+  addCss() {}
+}
+
 module('Unit | Controller | grants/index', (hooks) => {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    const mockStaticConfig = Service.extend({
-      getStaticConfig: () =>
-        Promise.resolve({
-          branding: {
-            stylesheet: '',
-            pages: {
-              faqUrl: '',
-            },
-          },
-        }),
-      addCss: () => {},
-    });
+    this.owner.register('service:app-static-config', MockConfigService);
 
-    this.owner.register('service:app-static-config', mockStaticConfig);
-  });
-
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let controller = this.owner.lookup('controller:grants/index');
-    assert.ok(controller);
+    this.controller = this.owner.lookup('controller:grants/index');
+    this.controller.currentUser = { user: { id: 0, isAdmin: false, isSubmitter: true } };
   });
 
   test('properly returns admin roles', function (assert) {
-    this.owner.register(
-      'service:current-user',
-      EmberObject.extend({
-        user: { isAdmin: true },
-      })
+    this.controller.currentUser = { user: { id: 0, isAdmin: true, isSubmitter: true } };
+    assert.strictEqual(
+      this.controller.get('adminColumns'),
+      this.controller.get('columns'),
+      'Should return admin columns'
     );
-
-    let controller = this.owner.lookup('controller:grants/index');
-
-    controller.set(
-      'currentUser.user',
-      EmberObject.create({
-        isAdmin: true,
-      })
-    );
-
-    assert.strictEqual(controller.get('adminColumns'), controller.get('columns'));
   });
 
   test('properly returns submitter roles', function (assert) {
-    let controller = this.owner.lookup('controller:grants/index');
-    controller.set(
-      'currentUser.user',
-      EmberObject.create({
-        isSubmitter: true,
-      })
+    assert.strictEqual(
+      this.controller.get('piColumns'),
+      this.controller.get('columns'),
+      'Should return submitter columns'
     );
+  });
 
-    assert.strictEqual(controller.get('piColumns'), controller.get('columns'));
+  test('displayAction updates tracked query params', function (assert) {
+    assert.equal(this.controller.page, 1, 'Page param should have default value');
+    assert.equal(this.controller.pageSize, 10, 'Page size param should have default value');
+
+    this.controller.send('displayAction', { currentPageNumber: 10, pageSize: 2 });
+
+    assert.equal(this.controller.page, 10, 'Page param should be updated');
+    assert.equal(this.controller.pageSize, 2, 'Page size param should be updated');
+  });
+
+  test('doQuery', async function (assert) {
+    assert.expect(8);
+
+    this.controller.store = {
+      query: (model, query) => {
+        // assert.equal(model, 'grant', 'Only grants should be queried');
+        switch (model) {
+          case 'grant':
+            assert.ok(query.page, 'Query should have pagination info');
+            return Promise.resolve([{ id: 10 }, { id: 11 }]);
+          case 'submission':
+            assert.notOk(query.page, 'Query should not have pagination info');
+            return Promise.resolve([
+              { id: 20, grants: [{ id: 11 }] },
+              { id: 21, grants: [{ id: 11 }] },
+            ]);
+          default:
+            assert.ok(false, 'Only submissions and grants should be queried here');
+        }
+        return Promise.resolve({});
+      },
+    };
+
+    assert.notOk(this.controller.queuedModel, 'Queued model should be empty');
+
+    await this.controller.doQuery({});
+
+    const result = this.controller.queuedModel;
+    assert.ok(result.grantMap, 'Grant mapping should exist');
+    assert.notOk(result.meta, 'No paging info present due to mocking');
+    assert.equal(result.grantMap.length, 2, 'grantMap should have 2 grants');
+    assert.equal(result.grantMap[0].submissions.length, 0, 'First grant should have 0 submissions');
+    assert.equal(result.grantMap[1].submissions.length, 2, 'Second grant should have 2 submissions');
   });
 });

--- a/tests/unit/controllers/submissions/index-test.js
+++ b/tests/unit/controllers/submissions/index-test.js
@@ -1,54 +1,63 @@
-/* eslint-disable ember/no-classic-classes */
-import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | submissions/index', (hooks) => {
+class MockConfigService extends Service {
+  getStaticConfig() {
+    return Promise.resolve({ branding: { stylesheet: '', pages: { faqUrl: '' } } });
+  }
+  addCss() {}
+}
+
+module('Unit | Controller | submissions/index', function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    const mockStaticConfig = Service.extend({
-      getStaticConfig: () =>
-        Promise.resolve({
-          branding: {
-            stylesheet: '',
-            pages: {
-              faqUrl: '',
-            },
-          },
-        }),
-      addCss: () => {},
-    });
+    this.owner.register('service:app-static-config', MockConfigService);
 
-    this.owner.register('service:app-static-config', mockStaticConfig);
-  });
-
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let controller = this.owner.lookup('controller:submissions/index');
-    assert.ok(controller);
+    this.controller = this.owner.lookup('controller:submissions/index');
+    this.controller.currentUser = { user: { id: 0, isAdmin: false, isSubmitter: true } };
   });
 
   test('properly returns admin roles', function (assert) {
-    let controller = this.owner.lookup('controller:submissions/index');
-    controller.set(
-      'currentUser.user',
-      EmberObject.create({
-        isAdmin: true,
-      })
-    );
-    assert.strictEqual(controller.get('columns.length'), 6);
+    this.controller.currentUser = { user: { id: 0, isAdmin: true, isSubmitter: true } };
+    assert.strictEqual(this.controller.columns.length, 6, 'Should get admin columns (with 6 cols)');
   });
 
   test('properly returns submitter roles', function (assert) {
-    let controller = this.owner.lookup('controller:submissions/index');
-    controller.set(
-      'currentUser.user',
-      EmberObject.create({
-        isSubmitter: true,
-      })
-    );
-    assert.strictEqual(controller.get('columns.length'), 7);
+    assert.strictEqual(this.controller.get('columns.length'), 7, 'Should get submitter columns (with 7 cols)');
+  });
+
+  /**
+   * Would be more helpful in an Acceptance test in order to check
+   * that URL query params are also updated
+   */
+  test('displayAction updates tracked query params', function (assert) {
+    assert.equal(this.controller.page, 1, 'Page param should have default value');
+    assert.equal(this.controller.pageSize, 10, 'Page size param should have default value');
+
+    this.controller.send('displayAction', { currentPageNumber: 10, pageSize: 2 });
+
+    assert.equal(this.controller.page, 10, 'Page param should be updated');
+    assert.equal(this.controller.pageSize, 2, 'Page size param should be updated');
+  });
+
+  test('doQuery makes a store query', async function (assert) {
+    assert.expect(4);
+
+    this.controller.store = {
+      query: (model, query) => {
+        assert.equal(model, 'submission', 'Only submissions should be queried');
+        assert.ok(query.page, 'Query should have pagination info');
+        return Promise.resolve({});
+      },
+    };
+
+    // Not called from a route's model hook, so no queued model
+    assert.notOk(this.controller.queuedModel, 'Queued model undefined');
+    // Don't actually need any params sent
+    await this.controller.doQuery({});
+
+    assert.deepEqual(this.controller.queuedModel, { submissions: {}, meta: undefined }, 'Queued model updated');
   });
 });

--- a/tests/unit/routes/grants/detail-test.js
+++ b/tests/unit/routes/grants/detail-test.js
@@ -4,9 +4,27 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Route | grants/detail', (hooks) => {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let route = this.owner.lookup('route:grants/detail');
-    assert.ok(route);
+  hooks.beforeEach(function () {
+    this.route = this.owner.lookup('route:grants/detail');
+    this.route.currentUser = { user: { id: 0, isAdmin: false, isSubmitter: true } };
+  });
+
+  test('Make sure grant and submissions are requested correctly', async function (assert) {
+    assert.expect(4);
+
+    this.route.store = {
+      findRecord: (model, id) => {
+        assert.equal(model, 'grant', 'Only grant should be requested via "findRecord"');
+        assert.equal(id, 0);
+        return Promise.resolve({});
+      },
+      query: (model, query) => {
+        assert.equal(model, 'submission', 'Only submission should be queried');
+        assert.deepEqual(query.page, { number: 1, size: 10, totals: true }, 'Should have pagination in query');
+        return Promise.resolve({});
+      },
+    };
+
+    await this.route.model({ grant_id: '0' });
   });
 });

--- a/tests/unit/routes/grants/index-test.js
+++ b/tests/unit/routes/grants/index-test.js
@@ -4,9 +4,55 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Route | grants/index', (hooks) => {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let route = this.owner.lookup('route:grants/index');
-    assert.ok(route);
+  hooks.beforeEach(function () {
+    this.route = this.owner.lookup('route:grants/index');
+    this.route.currentUser = {
+      user: { id: 0, isAdmin: false, isSubmitter: true },
+    };
+  });
+
+  test('Makes two requests', async function (assert) {
+    assert.expect(2);
+
+    this.route.store = {
+      query: (model, query) => {
+        switch (model) {
+          case 'grant':
+            assert.deepEqual(query.page, { number: 1, size: 10, totals: true }, 'Grant query should have pagination');
+            break;
+          case 'submission':
+            assert.notOk(query.page, 'Submission query should not have pagination');
+            break;
+          default:
+            assert.ok(false, 'Only "grant" and "submission" requests are expected');
+        }
+        return Promise.resolve([]);
+      },
+    };
+    await this.route.model({});
+  });
+
+  test('Submissions should be mapped to grants', async function (assert) {
+    this.route.store = {
+      query: (model, query) => {
+        switch (model) {
+          case 'grant':
+            return Promise.resolve([{ id: 0 }, { id: 1 }]);
+          case 'submission':
+            return Promise.resolve([
+              { id: 10, grants: [{ id: 0 }] },
+              { id: 11, grants: [{ id: 0 }] },
+            ]);
+          default:
+            assert.ok(false);
+            return Promise.resolve([]);
+        }
+      },
+    };
+
+    const result = await this.route.model({});
+    assert.equal(result.grantMap.length, 2);
+    assert.equal(result.grantMap[0].submissions.length, 2);
+    assert.equal(result.grantMap[1].submissions.length, 0);
   });
 });


### PR DESCRIPTION
(Will) Close https://github.com/eclipse-pass/main/issues/547

## Changes

* Grants list pagination largely working, global filter not hooked up

## Description

Adding support for server-side pagination, where previously we grabbed all records and did client side paging. For now, I've added some URL query params: 

* `page` [integer] : current page to show
* `pageSize` [integer] : number of items per page
* `filter` [string] : global search string to narrow items shown on the page
  * Currently only over `grant.projectName`

These query params will be automatically added to the URL and updated as the user uses the pagination controls, but the user can also manually update these parameters in their address bar, if desired

## TODO

* [x] Connect global search/filter on grants list
  * Should investigate using an index for this in a separate PR
* [x] Add pagination on submissions page
* [x] Add pagination to the grant details page
* ~[ ] Add pagination to the grant selector in the submission workflow~
  * Look into in a separate ticket, since the UI is different here
* ~[ ] Debounce requests as needed for the above implementations~
  * ~Need to see about separating debounce of pagination params vs filter (out-of-the-box they are handled with the same mechanism)~
  * ember-models-table should debounce requests automatically. E.g. global filter is handled here https://github.com/onechiporenko/ember-models-table/blob/f8d00579aa6684bcf0e874c384e03b508ec79ade/addon/components/models-table-server-paginated.ts#L321-L324 (link is to older v4.8.0, which is what is used in PASS currently). The request is handled by the `_loadDataOnce` which handles debouncing via the Ember runloop. Default is 500ms
* [ ] Try to refactor queries to reduce code duplication?
* [x] Need to handle global search strings better (e.g. spaces currently break the query)

## Questions

* How does the UI respond to invalid or out-of-bounds query params? E.g. setting `page=20` when there's only 1 page of results from the backend?
* What properties do we search over for the given pagination situations?
  * Related: We should probably setup indexes in the backend to support these filters/searches

## Testing

### Manual
You can check any of the above sections. Using pagination controls will update URL query parameters on the page.
Since we don't have a huge amount of test data, you can manually set page size to something small, like `pageSize=2` to force the results to render across multiple pages