### PR TITLE
Fix bad URL in contact link on 404 page

### DIFF
--- a/app/controllers/not-found-error.js
+++ b/app/controllers/not-found-error.js
@@ -1,13 +1,12 @@
 /* eslint-disable ember/no-get */
 import Controller from '@ember/controller';
-import { get } from '@ember/object';
 
 export default class NotFoundErrorController extends Controller {
   get icon() {
-    return `${get(this, 'model.config.branding.error.icon')}`;
+    return this.model.config.branding.error?.icon;
   }
 
   get contactUrl() {
-    return `${get(this, 'model.config.branding.pages.contactUrl')}`;
+    return this.model.config.branding.pages?.contactUrl;
   }
 }

--- a/app/templates/not-found-error.hbs
+++ b/app/templates/not-found-error.hbs
@@ -4,7 +4,7 @@
     <img src="{{this.icon}}" alt="Error icon" />
   </div>
   <div class="col my-auto">
-    <h2>404: Page not found</h1>
+    <h2>404: Page not found</h2>
     <p local-class="helpful-text">Looks like the page you're looking for does not exist. If you think there is a problem
       with the site, please
       {{#if this.contactUrl}}

--- a/app/templates/not-found-error.hbs
+++ b/app/templates/not-found-error.hbs
@@ -1,10 +1,17 @@
 {{outlet}}
 <div class="row">
-  <div class="col">
-    <img src="{{this.icon}}" local-class="error-icon" alt="Error icon" />
-    <p local-class="error-text"><br />404: Page not found</p>
+  <div class="col-2">
+    <img src="{{this.icon}}" alt="Error icon" />
+  </div>
+  <div class="col my-auto">
+    <h2>404: Page not found</h1>
     <p local-class="helpful-text">Looks like the page you're looking for does not exist. If you think there is a problem
       with the site, please
-      <a href="{{this.contactUrl}}">let us know</a>.</p>
+      {{#if this.contactUrl}}
+        <a href="{{this.contactUrl}}">let us know</a>.
+      {{else}}
+        contact your administrator.
+      {{/if}}
+    </p>
   </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/eclipse-pass/main/issues/806

Update 404 page to handle missing contact link

## Changes

* Get rid of the template string, which would report undefined values as string literal `'undefined'`
  * Message when URL is undefined changed to "Please contact your administrator"
* Is it fine to get rid of the stand alone `get` in this context?
* Update 404 page template
  * Don't add link if contact URL is not defined
  * Small restructure
