### PR TITLE
Clarify PASS support of web-link repositories

### DIFF
--- a/app/components/external-repo-review/index.hbs
+++ b/app/components/external-repo-review/index.hbs
@@ -1,0 +1,33 @@
+<tr>
+  <td class="text-nowrap text-center" id="externalSubmission">
+    <p class="{{if this.hasUnvisited 'text-danger'}}">
+      External Submission Required
+    </p>
+    {{#if this.hasUnvisited}}
+      <i class="fa fa-exclamation-triangle fa-2x notice-triangle text-danger"></i>
+    {{/if}}
+  </td>
+  <td>
+    <label class="">
+      You are required to make a submission to these repositories directly because PASS cannot integrate
+      with these systems.
+    </label>
+    <ul class="m-0 list-unstyled">
+      {{#each this.repoList as |entry|}}
+        <li>
+          <label class="pl-3 m-0 {{if entry.visited "" "font-weight-bold"}}">
+            {{entry.repo.name}}
+            <button
+              type="button"
+              class="btn btn-link py-0 {{if entry.visited "" "font-weight-bold"}}"
+              data-test-repo-link-button
+              {{on "click" (fn this.openWeblinkAlert entry.repo)}}
+            >
+              {{entry.repo.url}}
+            </button>
+          </label>
+        </li>
+      {{/each}}
+    </ul>
+  </td>
+</tr>

--- a/app/components/external-repo-review/index.hbs
+++ b/app/components/external-repo-review/index.hbs
@@ -9,17 +9,17 @@
   </td>
   <td>
     <label class="">
-      You are required to make a submission to these repositories directly because PASS cannot integrate
-      with these systems.
+      You are required to make a submission to these repositories directly because PASS cannot integrate with these
+      systems.
     </label>
     <ul class="m-0 list-unstyled">
       {{#each this.repoList as |entry|}}
         <li>
-          <label class="pl-3 m-0 {{if entry.visited "" "font-weight-bold"}}">
+          <label class="pl-3 m-0 {{if entry.visited '' 'font-weight-bold'}}">
             {{entry.repo.name}}
             <button
               type="button"
-              class="btn btn-link py-0 {{if entry.visited "" "font-weight-bold"}}"
+              class="btn btn-link py-0 {{if entry.visited '' 'font-weight-bold'}}"
               data-test-repo-link-button
               {{on "click" (fn this.openWeblinkAlert entry.repo)}}
             >

--- a/app/components/external-repo-review/index.js
+++ b/app/components/external-repo-review/index.js
@@ -1,0 +1,70 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+class VisitableRepo {
+  @tracked visited;
+  repo;
+
+  constructor(repo, visited) {
+    this.repo = repo;
+    this.visited = visited;
+  }
+}
+
+/**
+ * Assume:
+ *    - User must click link for all repos passed into this component
+ * args:
+ *    repos: array<Repository>
+ *    onAllExternalReposClicked: function - Action to trigger when all external repositories have been clicked
+ */
+export default class ExternalRepoReviewComponent extends Component {
+  @tracked repoList;
+
+  constructor() {
+    super(...arguments);
+    this.repoList = this.args.repos.map((repo) => new VisitableRepo(repo, false));
+  }
+
+  get hasUnvisited() {
+    return !this.allReposVisited;
+  }
+
+  get allReposVisited() {
+    return this.repoList.every((entry) => entry.visited);
+  }
+
+  handleRepo(repo) {
+    const index = this.repoList.findIndex((entry) => repo.id === entry.repo.id);
+    this.repoList[index].visited = true;
+
+    if (this.allReposVisited) {
+      this.args.onAllExternalReposClicked();
+    }
+  }
+
+  @action
+  openWeblinkAlert(repo) {
+    swal({
+      title: 'Notice!',
+      text: 'You are being sent to an external site. This will open a new tab.',
+      showCancelButton: true,
+      cancelButtonText: 'Cancel',
+      confirmButtonText: 'Open new tab',
+    }).then((value) => {
+      if (value.dismiss) {
+        return; // Don't redirect
+      }
+
+      $('#externalSubmission').modal('hide');
+
+      const win = window.open(repo.url, '_blank');
+      if (win) {
+        win.focus();
+      }
+
+      this.handleRepo(repo);
+    });
+  }
+}

--- a/app/components/workflow-repositories/index.hbs
+++ b/app/components/workflow-repositories/index.hbs
@@ -9,7 +9,17 @@
     below. PASS will help you to create submissions for these in the following steps:
   </p>
   <ul class="list-group" data-test-workflow-repositories-required-list>
-    {{#each @requiredRepositories as |repoInfo|}}
+    {{#each this.requiredIntegratedRepos as |repoInfo|}}
+      <RepositoryCard @repository={{repoInfo.repository}} @funders={{repoInfo.funders}} @type="required" />
+    {{/each}}
+  </ul>
+  <p class="lead text-muted mt-3">
+    You are required to submit to the following repositories, but PASS cannot make them for you. PASS can provide links to
+    these repositories with a summary of the information you've entered for your PASS submission before finalizing the
+    submission. You will need to follow those links in order to make a submission in those separate repository systems.
+  </p>
+  <ul class="list-group" data-test-workflow-repositories-required-weblink-list>
+    {{#each this.requiredWeblinkRepos as |repoInfo|}}
       <RepositoryCard @repository={{repoInfo.repository}} @funders={{repoInfo.funders}} @type="required" />
     {{/each}}
   </ul>
@@ -30,10 +40,6 @@
     Optional repositories
   </h4>
   <p class="lead text-muted">
-    {{! Text below is from previous version - not sure if we need to keep the text about "institutional" repos }}
-    {{!-- A Submission to the following will put you in compliance with your
-    {{#link-to "faq" (query-params anchor='#institution-policy')}}institution's open access policy{{/link-to}}.
-    If you are already making your publication openly available elsewhere (e.g. PubMed Central), this may be optional. --}}
     Choose whether you want to submit to zero or more of the following repositories. Selecting the repositories below is
     optional.
   </p>

--- a/app/components/workflow-repositories/index.hbs
+++ b/app/components/workflow-repositories/index.hbs
@@ -15,16 +15,17 @@
   </ul>
 
   {{#if this.requiredWeblinkRepos.length}}
-  <p class="lead text-muted mt-3">
-    You are required to submit to the following repositories, but PASS cannot make them for you. PASS can provide links to
-    these repositories with a summary of the information you've entered for your PASS submission before finalizing the
-    submission. You will need to follow those links in order to make a submission in those separate repository systems.
-  </p>
-  <ul class="list-group" data-test-workflow-repositories-required-weblink-list>
-    {{#each this.requiredWeblinkRepos as |repoInfo|}}
-      <RepositoryCard @repository={{repoInfo.repository}} @funders={{repoInfo.funders}} @type="required" />
-    {{/each}}
-  </ul>
+    <p class="lead text-muted mt-3">
+      You are required to submit to the following repositories, but PASS cannot make them for you. PASS can provide
+      links to these repositories with a summary of the information you've entered for your PASS submission before
+      finalizing the submission. You will need to follow those links in order to make a submission in those separate
+      repository systems.
+    </p>
+    <ul class="list-group" data-test-workflow-repositories-required-weblink-list>
+      {{#each this.requiredWeblinkRepos as |repoInfo|}}
+        <RepositoryCard @repository={{repoInfo.repository}} @funders={{repoInfo.funders}} @type="required" />
+      {{/each}}
+    </ul>
   {{/if}}
 {{/if}}
 

--- a/app/components/workflow-repositories/index.hbs
+++ b/app/components/workflow-repositories/index.hbs
@@ -13,6 +13,8 @@
       <RepositoryCard @repository={{repoInfo.repository}} @funders={{repoInfo.funders}} @type="required" />
     {{/each}}
   </ul>
+
+  {{#if this.requiredWeblinkRepos.length}}
   <p class="lead text-muted mt-3">
     You are required to submit to the following repositories, but PASS cannot make them for you. PASS can provide links to
     these repositories with a summary of the information you've entered for your PASS submission before finalizing the
@@ -23,6 +25,7 @@
       <RepositoryCard @repository={{repoInfo.repository}} @funders={{repoInfo.funders}} @type="required" />
     {{/each}}
   </ul>
+  {{/if}}
 {{/if}}
 
 {{#if @choiceRepositories}}

--- a/app/components/workflow-repositories/index.js
+++ b/app/components/workflow-repositories/index.js
@@ -39,6 +39,20 @@ export default class WorkflowRepositories extends Component {
 
   @tracked addedRepos = A([]);
 
+  // Separate out repositories that PASS has some level of integration
+  get requiredIntegratedRepos() {
+    return this.args.requiredRepositories.filter((repoInfo) => !repoInfo.repository._isWebLink);
+  }
+
+  // Separate out repositories that PASS has no integration
+  get requiredWeblinkRepos() {
+    return this.args.requiredRepositories.filter((repoInfo) => repoInfo.repository._isWebLink);
+  }
+
+  /**
+   * On component `did-insert`, make sure repositories in submission object
+   * are valid
+   */
   @action
   setupRepos() {
     set(this, 'addedRepos', this.getAddedRepositories());

--- a/app/components/workflow-review/index.css
+++ b/app/components/workflow-review/index.css
@@ -41,3 +41,7 @@ table td {
 .swal2-radio {
   flex-direction: column !important;
 }
+
+button[disabled] {
+  cursor: default;
+}

--- a/app/components/workflow-review/index.hbs
+++ b/app/components/workflow-review/index.hbs
@@ -34,7 +34,7 @@
             {{#if this.mustVisitWeblink}}
               <tr>
                 <td class="text-nowrap text-center" id="externalSubmission">
-                  <p class="{{if this.disableSubmit "text-danger"}}">
+                  <p class="{{if this.disableSubmit 'text-danger'}}">
                     External Submission Required
                   </p>
                   {{#if this.disableSubmit}}
@@ -43,21 +43,21 @@
                 </td>
                 <td>
                   <label class="">
-                    You are required to make a submission to these repositories directly because PASS cannot
-                    integrate with these systems.
+                    You are required to make a submission to these repositories directly because PASS cannot integrate
+                    with these systems.
                   </label>
                   <ul class="m-0 list-unstyled">
                     {{#each this.weblinkRepos as |repo|}}
                       <li>
-                        <label class="pl-3">
-                          {{ repo.name }}
+                        <label class="pl-3 m-0">
+                          {{repo.name}}
                           <button
                             type="button"
-                            class="btn btn-link {{if this.disableSubmit "font-weight-bold"}}"
+                            class="btn btn-link {{if this.disableSubmit 'font-weight-bold'}} py-0"
                             data-test-repo-link-button
                             {{action "openWeblinkAlert" repo}}
                           >
-                            {{ repo.url }}
+                            {{repo.url}}
                           </button>
                         </label>
 
@@ -250,11 +250,7 @@
     {{@waitingMessage}}
   </button>
 {{else if this.disableSubmit}}
-  <button
-    class="btn btn-primary pull-right submit"
-    data-test-workflow-review-submit
-    disabled
-  >
+  <button class="btn btn-primary pull-right submit" data-test-workflow-review-submit disabled>
     {{this.submitButtonText}}
   </button>
 {{else}}

--- a/app/components/workflow-review/index.hbs
+++ b/app/components/workflow-review/index.hbs
@@ -31,20 +31,54 @@
         </div>
         <table local-class="review-step-table" class="table table-responsive-sm table-bordered w-100">
           <tbody>
+            {{#if this.mustVisitWeblink}}
+              <tr>
+                <td class="text-nowrap text-center" id="externalSubmission">
+                  <p class="{{if this.disableSubmit "text-danger"}}">
+                    External Submission Required
+                  </p>
+                  {{#if this.disableSubmit}}
+                    <i class="fa fa-exclamation-triangle fa-2x notice-triangle text-danger"></i>
+                  {{/if}}
+                </td>
+                <td>
+                  <label class="">
+                    You are required to make a submission to these repositories directly because PASS cannot
+                    integrate with these systems.
+                  </label>
+                  <ul class="m-0 list-unstyled">
+                    {{#each this.weblinkRepos as |repo|}}
+                      <li>
+                        <label class="pl-3">
+                          {{ repo.name }}
+                          <button
+                            type="button"
+                            class="btn btn-link {{if this.disableSubmit "font-weight-bold"}}"
+                            data-test-repo-link-button
+                            {{action "openWeblinkAlert" repo}}
+                          >
+                            {{ repo.url }}
+                          </button>
+                        </label>
+
+                      </li>
+                    {{/each}}
+                  </ul>
+                </td>
+              </tr>
+            {{/if}}
+
             <tr>
               <td local-class="max-width">
                 Repositories
-                <span
-                  tooltip-position="right"
-                  tooltip="Submission into these repositories is required according to the respective policies."
-                >
-                  <i class="fas fa-info-circle"></i>
-                </span>
               </td>
               <td>
-                <ul data-test-workflow-review-repository-list>
+                <p>
+                  Submission into these repositories is required according to the respective policies.
+                </p>
+                <ul class="m-0 list-unstyled" data-test-workflow-review-repository-list>
                   {{#each @submission.repositories as |repository|}}
-                    <li>
+                    <li class="pl-3">
                       {{repository.name}}
                     </li>
                   {{/each}}
@@ -52,37 +86,6 @@
               </td>
             </tr>
 
-            {{#if this.mustVisitWeblink}}
-              <tr>
-                <td class="text-nowrap text-center" id="externalSubmission">
-                  External Submission Required
-                  <br />
-                  {{#if this.disableSubmit}}
-                    <i class="fa fa-exclamation-triangle fa-2x mt-3 notice-triangle"></i>
-                  {{/if}}
-                </td>
-                <td>
-                  <label class="">
-                    Please visit the following web portal to submit your manuscript directly. Metadata displayed above
-                    could be used to aid in your submission progress.
-                  </label>
-                  <ul class="m-0">
-                    {{#each this.weblinkRepos as |repo|}}
-                      <li>
-                        <button
-                          type="button"
-                          class="btn btn-link"
-                          data-test-repo-link-button
-                          {{action "openWeblinkAlert" repo}}
-                        >
-                          {{get repo "url"}}
-                        </button>
-                      </li>
-                    {{/each}}
-                  </ul>
-                </td>
-              </tr>
-            {{/if}}
             <tr>
               <td>
                 Grants
@@ -245,6 +248,14 @@
 {{#if @uploading}}
   <button class="btn btn-primary pull-right submit" disabled>
     {{@waitingMessage}}
+  </button>
+{{else if this.disableSubmit}}
+  <button
+    class="btn btn-primary pull-right submit"
+    data-test-workflow-review-submit
+    disabled
+  >
+    {{this.submitButtonText}}
   </button>
 {{else}}
   <button

--- a/app/components/workflow-review/index.hbs
+++ b/app/components/workflow-review/index.hbs
@@ -32,40 +32,10 @@
         <table local-class="review-step-table" class="table table-responsive-sm table-bordered w-100">
           <tbody>
             {{#if this.mustVisitWeblink}}
-              <tr>
-                <td class="text-nowrap text-center" id="externalSubmission">
-                  <p class="{{if this.disableSubmit 'text-danger'}}">
-                    External Submission Required
-                  </p>
-                  {{#if this.disableSubmit}}
-                    <i class="fa fa-exclamation-triangle fa-2x notice-triangle text-danger"></i>
-                  {{/if}}
-                </td>
-                <td>
-                  <label class="">
-                    You are required to make a submission to these repositories directly because PASS cannot integrate
-                    with these systems.
-                  </label>
-                  <ul class="m-0 list-unstyled">
-                    {{#each this.weblinkRepos as |repo|}}
-                      <li>
-                        <label class="pl-3 m-0">
-                          {{repo.name}}
-                          <button
-                            type="button"
-                            class="btn btn-link {{if this.disableSubmit 'font-weight-bold'}} py-0"
-                            data-test-repo-link-button
-                            {{action "openWeblinkAlert" repo}}
-                          >
-                            {{repo.url}}
-                          </button>
-                        </label>
-
-                      </li>
-                    {{/each}}
-                  </ul>
-                </td>
-              </tr>
+              <ExternalRepoReview
+                @repos={{this.weblinkRepos}}
+                @onAllExternalReposClicked={{this.onAllExternalReposClicked}}
+              />
             {{/if}}
 
             <tr>

--- a/app/components/workflow-review/index.js
+++ b/app/components/workflow-review/index.js
@@ -6,7 +6,6 @@ import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency-decorators';
 import { later } from '@ember/runloop';
-import ENV from 'pass-ui/config/environment';
 
 export default class WorkflowReview extends Component {
   @service workflow;
@@ -54,7 +53,7 @@ export default class WorkflowReview extends Component {
 
   get disableSubmit() {
     const needsToVisitWeblink = this.mustVisitWeblink && !this.hasVisitedWeblink;
-    return needsToVisitWeblink;
+    return this.args.uploading || needsToVisitWeblink;
   }
 
   get userIsPreparer() {
@@ -64,10 +63,6 @@ export default class WorkflowReview extends Component {
 
   get submitButtonText() {
     return this.userIsPreparer ? 'Request approval' : 'Submit';
-  }
-
-  get isTest() {
-    return ENV.environment === 'test';
   }
 
   @task

--- a/app/controllers/submissions/new/repositories.js
+++ b/app/controllers/submissions/new/repositories.js
@@ -5,7 +5,7 @@ import { action, computed, get, set } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
-export default class SubmissionsNewPolicies extends Controller {
+export default class SubmissionsNewRepositories extends Controller {
   @service workflow;
 
   @alias('model.newSubmission') submission;

--- a/tests/integration/components/external-repo-review-test.js
+++ b/tests/integration/components/external-repo-review-test.js
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'pass-ui/tests/helpers';
+import { click, render, waitFor } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | external-repo-review', (hooks) => {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.repos = [
+      { id: 1, name: 'Repo 1', url: 'https://example.com/repository1' },
+      { id: 2, name: 'Repo 2', url: 'https://example.com/repository2' },
+    ];
+    this.onExternalReposClicked = () => {};
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <ExternalRepoReview
+        @repos={{this.repos}}
+        @onExternalReposClicked={{this.onExternalReposClicked}}
+      />
+    `);
+
+    assert
+      .dom(this.element)
+      .containsText(
+        'You are required to make a submission to these repositories directly because PASS cannot integrate with these systems.'
+      );
+
+    const li = this.element.querySelectorAll('li');
+    assert.equal(li.length, 2, 'Should have 2 list elements for repos');
+    assert.dom('i.text-danger').exists();
+  });
+
+  test('Links unbold when clicked', async function (assert) {
+    await render(hbs`
+      <ExternalRepoReview
+        @repos={{this.repos}}
+        @onAllExternalReposClicked={{this.onExternalReposClicked}}
+      />
+    `);
+
+    const btn = this.element.querySelectorAll('button');
+    assert.dom(btn[0]).hasClass('font-weight-bold');
+
+    await click(btn[0]);
+
+    await waitFor(document.querySelector('button.swal2-confirm'));
+    await click(document.querySelector('button.swal2-confirm'));
+
+    assert.dom(btn[0]).doesNotHaveClass('font-weight-bold');
+  });
+
+  test('Clicking all links removes alert icon', async function (assert) {
+    await render(hbs`
+      <ExternalRepoReview
+        @repos={{this.repos}}
+        @onAllExternalReposClicked={{this.onExternalReposClicked}}
+      />
+    `);
+
+    const btn = this.element.querySelectorAll('button');
+    assert.equal(btn.length, 2, 'Should have 2 list elements for repos');
+    await click(btn[0]);
+
+    await waitFor(document.querySelector('button.swal2-confirm'));
+    await click(document.querySelector('button.swal2-confirm'));
+
+    await click(btn[1]);
+
+    await waitFor(document.querySelector('button.swal2-confirm'));
+    await click(document.querySelector('button.swal2-confirm'));
+
+    assert.dom('i.fa-exclamation-triangle').doesNotExist();
+    assert.dom('button.font-weight-bold').doesNotExist('There should be no bolded repo links');
+  });
+});

--- a/tests/integration/components/workflow-repositories-test.js
+++ b/tests/integration/components/workflow-repositories-test.js
@@ -27,6 +27,9 @@ module('Integration | Component | workflow repositories', (hooks) => {
     `);
 
     assert.ok(true);
+    assert
+      .dom('[data-test-workflow-repositories-required-weblink-list]')
+      .doesNotExist('Separate weblink repos list should not be rendered');
   });
 
   test('required repositories should display with no checkboxes', async function (assert) {

--- a/tests/integration/components/workflow-review-test.js
+++ b/tests/integration/components/workflow-review-test.js
@@ -7,6 +7,11 @@ import { module, test } from 'qunit';
 import { click, render, waitUntil, waitFor } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
+/**
+ * `EmberObject.create` used in these tests because they need to serve as
+ * EmberProxy objects that have a `.get` function
+ */
+
 module('Integration | Component | workflow review', (hooks) => {
   setupRenderingTest(hooks);
   setupMirage(hooks);
@@ -19,21 +24,14 @@ module('Integration | Component | workflow review', (hooks) => {
   });
 
   test('it renders', async function (assert) {
-    let submission = EmberObject.create({
-      metadata: '[]',
-      repositories: [],
-    });
-    let publication = EmberObject.create({});
-    let files = [EmberObject.create({})];
-
-    this.set('submission', submission);
-    this.set('publication', publication);
-    this.set('submit', (actual) => {});
-    this.set('loadPrevious', (actual) => {});
-    this.set('files', files);
-    this.set('comment', '');
-    this.set('uploading', '');
-    this.set('waitingMessage', '');
+    this.submission = { metadata: '[]', repositories: [] };
+    this.publication = {};
+    this.submit = () => {};
+    this.loadPrevious = () => {};
+    this.files = [{}];
+    this.comment = '';
+    this.uploading = '';
+    this.waitingMessage = '';
 
     await render(hbs`
       <WorkflowReview
@@ -194,40 +192,30 @@ module('Integration | Component | workflow review', (hooks) => {
     let repo2 = EmberObject.create({
       id: 'test:repo2',
       integrationType: 'web-link',
-      url: '',
-      name: 'repo2',
+      url: 'https://example.com/moo',
+      name: 'External Repository [2]',
       _isWebLink: true,
     });
     let submitted = false;
 
-    this.owner.register(
-      'service:current-user',
-      EmberObject.extend({
-        user: { id: 'pi' },
-      })
-    );
+    this.owner.register('service:current-user', EmberObject.extend({ user: { id: 'pi' } }));
 
     let submission = EmberObject.create({
-      submitter: {
-        id: 'pi',
-      },
+      submitter: { id: 'pi' },
       preparers: A([get(this, 'currentUser.user')]),
       repositories: A([repo1, repo2]),
       metadata: '[]',
     });
 
-    let publication = EmberObject.create({});
-    let files = [EmberObject.create({})];
-
-    this.set('submission', submission);
-    this.set('publication', publication);
-    this.set('submit', (actual) => {
+    this.submission = submission;
+    this.publication = {};
+    this.files = [{}];
+    this.comment = '';
+    this.uploading = '';
+    this.waitingMessage = '';
+    this.submit = () => {
       submitted = true;
-    });
-    this.set('files', files);
-    this.set('comment', '');
-    this.set('uploading', '');
-    this.set('waitingMessage', '');
+    };
 
     await render(hbs`
       <WorkflowReview
@@ -241,9 +229,15 @@ module('Integration | Component | workflow review', (hooks) => {
       />
     `);
 
+    assert
+      .dom('[data-test-workflow-review-submit]')
+      .isDisabled('Submit should be disabled until web-link repo is clicked');
+
     // Click on web-link repository and then confirm
     await click('[data-test-repo-link-button]');
     await click(document.querySelector('.swal2-confirm'));
+
+    assert.dom('[data-test-workflow-review-submit]').isNotDisabled();
 
     // Click on submit
     await click('.submit');
@@ -263,46 +257,40 @@ module('Integration | Component | workflow review', (hooks) => {
     assert.strictEqual(submission.get('repositories.firstObject.id'), repo1.id);
   });
 
-  test('submission failure: no web-link click', async function (assert) {
-    let controller = this.owner.lookup('controller:submissions/new/review');
-    assert.ok(controller);
-
-    let repo2 = EmberObject.create({
-      id: 'test:repo2',
+  test('Submission disabled until all web-link repos visited', async function (assert) {
+    const repo1 = EmberObject.create({
+      id: 'test:repo1',
       integrationType: 'web-link',
-      name: 'repo2',
+      url: 'https://example.com/test-repo1',
+      name: 'repo1',
       _isWebLink: true,
     });
-    let submitted = false;
+    const repo2 = EmberObject.create({
+      id: 'test:repo2',
+      integrationType: 'web-link',
+      url: 'https://example.com/moo',
+      name: 'External Repository [2]',
+      _isWebLink: true,
+    });
 
-    this.owner.register(
-      'service:current-user',
-      EmberObject.extend({
-        user: { id: 'pi' },
-      })
-    );
+    this.owner.register('service:current-user', EmberObject.extend({ user: { id: 'pi' } }));
 
-    let submission = EmberObject.create({
-      submitter: {
-        id: 'pi',
-      },
+    const submission = EmberObject.create({
+      submitter: { id: 'pi' },
       preparers: A([get(this, 'currentUser.user')]),
-      repositories: A([repo2]),
+      repositories: A([repo1, repo2]),
       metadata: '[]',
     });
 
-    let publication = EmberObject.create({});
-    let files = [EmberObject.create({})];
-
-    this.set('submission', submission);
-    this.set('publication', publication);
-    this.set('submit', (actual) => {
+    this.submission = submission;
+    this.publication = {};
+    this.files = [{}];
+    this.comment = '';
+    this.uploading = '';
+    this.waitingMessage = '';
+    this.submit = () => {
       submitted = true;
-    });
-    this.set('files', files);
-    this.set('comment', '');
-    this.set('uploading', '');
-    this.set('waitingMessage', '');
+    };
 
     await render(hbs`
       <WorkflowReview
@@ -316,21 +304,20 @@ module('Integration | Component | workflow review', (hooks) => {
       />
     `);
 
-    // Click on submit
-    await click('.submit');
-
-    await waitUntil(() => !document.querySelector('.swal2-title'), { timeout: 500 });
-
-    await waitFor('.flash-message.alert.alert-warning');
     assert
-      .dom('.flash-message.alert.alert-warning')
-      .includesText(
-        'Please visit the following web portal to submit your manuscript directly. Metadata displayed above could be used to aid in your submission progress.'
-      );
+      .dom('[data-test-workflow-review-submit]')
+      .isDisabled('Submit should be disabled until web-link repo is clicked');
 
-    assert.strictEqual(document.querySelector('.swal2-title'), null);
+    const weblinks = document.querySelectorAll('[data-test-repo-link-button]');
+    assert.equal(weblinks.length, 2, 'Should show 2 external repository links');
 
-    assert.false(submitted);
+    await click(weblinks[0]);
+    await click(document.querySelector('.swal2-confirm'));
+    assert.dom('[data-test-workflow-review-submit]').isDisabled();
+
+    await click(weblinks[1]);
+    await click(document.querySelector('.swal2-confirm'));
+    assert.dom('[data-test-workflow-review-submit]').isNotDisabled();
   });
 
   test('submission failure: no repository agreement', async function (assert) {
@@ -400,6 +387,78 @@ module('Integration | Component | workflow review', (hooks) => {
     assert.true(document.querySelector('.swal2-content').textContent.includes(repo1.get('name')));
 
     await click(document.querySelector('.swal2-confirm'));
+
+    assert.false(submitted);
+  });
+  /**
+   * User should not be able to click the Submit button before all web-link repositories are visited
+   * so this error shouldn't be encountered in the UI
+   */
+  test.skip('submission failure: no web-link click', async function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/review');
+    assert.ok(controller);
+
+    let repo2 = EmberObject.create({
+      id: 'test:repo2',
+      integrationType: 'web-link',
+      name: 'repo2',
+      _isWebLink: true,
+      url: 'https://example.com/moo',
+    });
+    let submitted = false;
+
+    this.owner.register(
+      'service:current-user',
+      EmberObject.extend({
+        user: { id: 'pi' },
+      })
+    );
+
+    let submission = EmberObject.create({
+      submitter: { id: 'pi' },
+      preparers: A([get(this, 'currentUser.user')]),
+      repositories: A([repo2]),
+      metadata: '[]',
+    });
+
+    let publication = EmberObject.create({});
+    let files = [EmberObject.create({})];
+
+    this.set('submission', submission);
+    this.set('publication', publication);
+    this.set('submit', (actual) => {
+      submitted = true;
+    });
+    this.set('files', files);
+    this.set('comment', '');
+    this.set('uploading', '');
+    this.set('waitingMessage', '');
+
+    await render(hbs`
+      <WorkflowReview
+        @submission={{this.submission}}
+        @publication={{this.publication}}
+        @previouslyUploadedFiles={{this.files}}
+        @comment={{this.comment}}
+        @submit={{action this.submit}}
+        @uploading={{this.uploading}}
+        @waitingMessage={{this.waitingMessage}}
+      />
+    `);
+
+    // Click on submit
+    await click('.submit');
+
+    await waitUntil(() => !document.querySelector('.swal2-title'), { timeout: 500 });
+
+    await waitFor('.flash-message.alert.alert-warning');
+    assert
+      .dom('.flash-message.alert.alert-warning')
+      .includesText(
+        'Please visit the following web portal to submit your manuscript directly. Metadata displayed above could be used to aid in your submission progress.'
+      );
+
+    assert.strictEqual(document.querySelector('.swal2-title'), null);
 
     assert.false(submitted);
   });

--- a/tests/integration/components/workflow-review-test.js
+++ b/tests/integration/components/workflow-review-test.js
@@ -4,7 +4,7 @@ import EmberObject, { get } from '@ember/object';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
-import { click, render, waitUntil, waitFor } from '@ember/test-helpers';
+import { click, render, waitFor } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 /**
@@ -387,78 +387,6 @@ module('Integration | Component | workflow review', (hooks) => {
     assert.true(document.querySelector('.swal2-content').textContent.includes(repo1.get('name')));
 
     await click(document.querySelector('.swal2-confirm'));
-
-    assert.false(submitted);
-  });
-  /**
-   * User should not be able to click the Submit button before all web-link repositories are visited
-   * so this error shouldn't be encountered in the UI
-   */
-  test.skip('submission failure: no web-link click', async function (assert) {
-    let controller = this.owner.lookup('controller:submissions/new/review');
-    assert.ok(controller);
-
-    let repo2 = EmberObject.create({
-      id: 'test:repo2',
-      integrationType: 'web-link',
-      name: 'repo2',
-      _isWebLink: true,
-      url: 'https://example.com/moo',
-    });
-    let submitted = false;
-
-    this.owner.register(
-      'service:current-user',
-      EmberObject.extend({
-        user: { id: 'pi' },
-      })
-    );
-
-    let submission = EmberObject.create({
-      submitter: { id: 'pi' },
-      preparers: A([get(this, 'currentUser.user')]),
-      repositories: A([repo2]),
-      metadata: '[]',
-    });
-
-    let publication = EmberObject.create({});
-    let files = [EmberObject.create({})];
-
-    this.set('submission', submission);
-    this.set('publication', publication);
-    this.set('submit', (actual) => {
-      submitted = true;
-    });
-    this.set('files', files);
-    this.set('comment', '');
-    this.set('uploading', '');
-    this.set('waitingMessage', '');
-
-    await render(hbs`
-      <WorkflowReview
-        @submission={{this.submission}}
-        @publication={{this.publication}}
-        @previouslyUploadedFiles={{this.files}}
-        @comment={{this.comment}}
-        @submit={{action this.submit}}
-        @uploading={{this.uploading}}
-        @waitingMessage={{this.waitingMessage}}
-      />
-    `);
-
-    // Click on submit
-    await click('.submit');
-
-    await waitUntil(() => !document.querySelector('.swal2-title'), { timeout: 500 });
-
-    await waitFor('.flash-message.alert.alert-warning');
-    assert
-      .dom('.flash-message.alert.alert-warning')
-      .includesText(
-        'Please visit the following web portal to submit your manuscript directly. Metadata displayed above could be used to aid in your submission progress.'
-      );
-
-    assert.strictEqual(document.querySelector('.swal2-title'), null);
 
     assert.false(submitted);
   });


### PR DESCRIPTION
[Will fix] https://github.com/eclipse-pass/main/issues/815

**Pending redesign and new wording approval**

* `web-link repository`: repositories that PASS can't integrate with. PASS cannot make a submission on behalf of our users to these repositories. Instead, the users must go to these repositories and manually create their own submission.

## Changes

* Repositories step
  * Break out web-link repositories into separate section with brief description
* Review step
  * web-link row moved to the top
  * web-link row text colored red, links bolded. Color changes to black, links unbold when the user visits the links
  * Submit button disabled until all web-links are visited
  * Other minor UI tweaks
    * Bullet points in repository lists removed
    * Spacing of repository lists normalized
    * Weblink repository names AND links provided


## TODO

* [ ] Add web-link description to Files step conditionally if a web-link repo is associated with the submission
* [x] Update Review step to better highlight the web-link repo section and display expectations to user
* [x] Review the review step UX
  * [x] We should indicate which weblink repo links a user still need to click on. If there are multiple weblink repos on the submission, the user needs to be able to tell which one(s) they may still need to visit to proceed with the submission
* [x] Updating tests!
  * [x] One test in `workflow-review-test` skipped that tests for an error popup when a user clicks the Submit button before visiting weblink repos. Since this button is now disabled until the links are clicked, we can probably remove this logic and test