### PR TITLE
Delete files when removed from Draft submissions

### DIFF
--- a/app/adapters/file.js
+++ b/app/adapters/file.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class FileAdapter extends ApplicationAdapter {
+  deleteRecord(store, type, snapshot) {
+    console.warn('File deletion cannot be rolled back');
+    // Can't use this.buildURL, as that will append the ember-data File path, which we don't want
+    const url = `/${this.namespace}${snapshot.attr('uri')}`;
+    return fetch(url, {
+      method: 'DELETE',
+    }).then(() => super.deleteRecord(store, type, snapshot));
+  }
+}

--- a/app/components/workflow-files/index.js
+++ b/app/components/workflow-files/index.js
@@ -129,9 +129,10 @@ export default class WorkflowFiles extends Component {
       return;
     }
 
-    file.set('submission', undefined);
-    await file.save();
-    file.unloadRecord();
+    // Delete record without a chance to roll back
+    // This will automatically remove the uploaded bytes of the original file
+    // then delete the File model record
+    await file.destroyRecord();
   }
 
   @action

--- a/app/components/workflow-files/index.js
+++ b/app/components/workflow-files/index.js
@@ -115,6 +115,7 @@ export default class WorkflowFiles extends Component {
       this.args.newFiles.pushObject(newFile);
     } catch (error) {
       FileUpload.file.state = 'aborted';
+      console.error(error);
     }
 
     return true;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,6 +1,6 @@
 import { camelize } from '@ember/string';
 import { discoverEmberDataModels } from 'ember-cli-mirage';
-import { createServer, JSONAPISerializer } from 'miragejs';
+import { createServer, JSONAPISerializer, Response } from 'miragejs';
 import doiJournals from './custom-fixtures/nih-submission/doi-journals';
 import schemas from './routes/schemas';
 import ENV from 'pass-ui/config/environment';
@@ -110,6 +110,9 @@ export default function (config) {
         const attrs = this.normalizedRequestAttrs();
 
         return schema.create('file', attrs);
+      });
+      this.delete('/data/file/:id/:name', (_schema, _request) => {
+        return new Response(200);
       });
 
       /** Schema Service */


### PR DESCRIPTION
Resolves https://github.com/eclipse-pass/main/issues/514

- Update the `deleteFile` function in the Files step to call the file service to delete the file, then delete the File object in the DB
- Add console log in the same place to print when an error occurs
- Updates to tests
  - Check to make sure `file.destroyRecord` is called
  - General test code updates