### PR TITLE
UI shouldn't send empty requests to metadata schema service

### DIFF
--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -58,6 +58,10 @@ export default class MetadataSchemaService extends Service {
    * @returns {array} list of schemas relevant to the given repositories
    */
   async getMetadataSchemas(repositories) {
+    if (!repositories) {
+      return [];
+    }
+
     const areObjects = repositories.map((repos) => typeof repos).includes('object');
     if (areObjects) {
       // If we've gotten repository objects, map them to their IDs
@@ -70,6 +74,10 @@ export default class MetadataSchemaService extends Service {
         'Content-Type': 'application/json; charset=utf-8',
       },
     };
+
+    if (!Array.isArray(repositories) || repositories.length === 0) {
+      return [];
+    }
 
     try {
       let response = await this._fetchSchemas(this.url(repositories, true), options);
@@ -407,7 +415,8 @@ export default class MetadataSchemaService extends Service {
       'volume',
     ];
 
-    const schemas = await this.getMetadataSchemas(await submission.repositories);
+    const repos = await submission.repositories.toArray();
+    const schemas = await this.getMetadataSchemas(repos);
     const titleMap = this.getFieldTitleMap(schemas);
     const metadata = JSON.parse(submission.metadata);
 

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | workflow-metadata', (hooks) => {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const repositories = A();
+    const repositories = A([{ id: 0 }]);
     const journal = EmberObject.create({
       issns: [],
     });

--- a/tests/unit/services/metadata-schema-test.js
+++ b/tests/unit/services/metadata-schema-test.js
@@ -277,6 +277,6 @@ module('Unit | Service | metadata-schema', (hooks) => {
 
     service.getMetadataSchemas([]);
 
-    assert.ok(serviceFetchFake.notCalled, '_fetchSchemas should have been called');
+    assert.ok(serviceFetchFake.notCalled, '_fetchSchemas should not have been called');
   });
 });

--- a/tests/unit/services/metadata-schema-test.js
+++ b/tests/unit/services/metadata-schema-test.js
@@ -216,7 +216,7 @@ module('Unit | Service | metadata-schema', (hooks) => {
   test('Should format complex metadata', async function (assert) {
     const service = this.owner.lookup('service:metadata-schema');
     const submission = EmberObject.create({
-      repositories: [],
+      repositories: [{ id: 0 }],
       metadata: JSON.stringify({
         issns: [{ issn: '123-moo' }, { issn: 'moo-321', pubType: 'Print' }],
       }),
@@ -269,5 +269,14 @@ module('Unit | Service | metadata-schema', (hooks) => {
     const expected = { two: 'moo too' };
 
     assert.deepEqual(service.mergeBlobs(b1, b2, list), expected);
+  });
+
+  test('No backend request if no repositories are passed', async function (assert) {
+    const service = this.owner.lookup('service:metadata-schema');
+    const serviceFetchFake = sinon.replace(service, '_fetchSchemas', sinon.fake());
+
+    service.getMetadataSchemas([]);
+
+    assert.ok(serviceFetchFake.notCalled, '_fetchSchemas should have been called');
   });
 });


### PR DESCRIPTION
Resolves https://github.com/eclipse-pass/main/issues/876

- Converts proxies where necessary with `toArray()`
- Prevents REST call when no or empty args passed to service