### PR TITLE
File deletion v2

### DIFF
--- a/app/adapters/file.js
+++ b/app/adapters/file.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class FileAdapter extends ApplicationAdapter {
+  deleteRecord(store, type, snapshot) {
+    console.warn('File deletion cannot be rolled back');
+    // Can't use this.buildURL, as that will append the ember-data File path, which we don't want
+    const url = `/${this.namespace}${snapshot.attr('uri')}`;
+    return fetch(url, {
+      method: 'DELETE',
+    }).then(() => super.deleteRecord(store, type, snapshot));
+  }
+}

--- a/app/adapters/file.js
+++ b/app/adapters/file.js
@@ -2,6 +2,7 @@ import ApplicationAdapter from './application';
 
 export default class FileAdapter extends ApplicationAdapter {
   /**
+   * ### This can't be rolled back ###
    * Overrides an Ember Model's base destroyRecord function.
    *
    * First call our File Service to delete file bytes, then
@@ -14,7 +15,6 @@ export default class FileAdapter extends ApplicationAdapter {
    * requests fail, same as default behavior.
    */
   deleteRecord(store, type, snapshot) {
-    console.warn('File deletion cannot be rolled back');
     // Can't use this.buildURL, as that will append the ember-data File path, which we don't want
     let url = snapshot.attr('uri');
     if (!url.startsWith('/')) {

--- a/app/adapters/file.js
+++ b/app/adapters/file.js
@@ -4,9 +4,17 @@ export default class FileAdapter extends ApplicationAdapter {
   deleteRecord(store, type, snapshot) {
     console.warn('File deletion cannot be rolled back');
     // Can't use this.buildURL, as that will append the ember-data File path, which we don't want
-    const url = `/${this.namespace}${snapshot.attr('uri')}`;
+    let url = snapshot.attr('uri');
+    if (!url.startsWith('/')) {
+      url = `/${url}`;
+    }
     return fetch(url, {
       method: 'DELETE',
-    }).then(() => super.deleteRecord(store, type, snapshot));
+    }).then((response) => {
+      if (!response.ok) {
+        throw new Error('Delete request to the file service failed');
+      }
+      return super.deleteRecord(store, type, snapshot);
+    });
   }
 }

--- a/app/adapters/file.js
+++ b/app/adapters/file.js
@@ -1,6 +1,18 @@
 import ApplicationAdapter from './application';
 
 export default class FileAdapter extends ApplicationAdapter {
+  /**
+   * Overrides an Ember Model's base destroyRecord function.
+   *
+   * First call our File Service to delete file bytes, then
+   * destroy the metadata record using the standard a
+   * `destroyRecord` call. If the call to the File Service fails
+   * an error will be throw and default destroyRecord will
+   * not be called
+   *
+   * Will throw errors back to caller if any of the network
+   * requests fail, same as default behavior.
+   */
   deleteRecord(store, type, snapshot) {
     console.warn('File deletion cannot be rolled back');
     // Can't use this.buildURL, as that will append the ember-data File path, which we don't want

--- a/app/components/workflow-files/index.hbs
+++ b/app/components/workflow-files/index.hbs
@@ -110,7 +110,12 @@
                 />
               </td>
               <td class="text-center vertical-align-middle">
-                <button type="button" class="btn btn-outline-danger" {{on "click" (fn this.deleteExistingFile file)}}>
+                <button
+                  type="button"
+                  class="btn btn-outline-danger"
+                  data-test-remove-file-button
+                  {{on "click" (fn this.deleteExistingFile file)}}
+                >
                   Remove
                 </button>
               </td>

--- a/app/components/workflow-files/index.js
+++ b/app/components/workflow-files/index.js
@@ -129,9 +129,10 @@ export default class WorkflowFiles extends Component {
       return;
     }
 
-    file.set('submission', undefined);
-    await file.save();
-    file.unloadRecord();
+    // Delete record without a chance to roll back
+    // This will automatically remove the uploaded bytes of the original file
+    // then delete the File model record
+    await file.destroyRecord();
   }
 
   @action

--- a/app/components/workflow-files/index.js
+++ b/app/components/workflow-files/index.js
@@ -63,9 +63,9 @@ export default class WorkflowFiles extends Component {
       cancelButtonColor: '#d33',
       confirmButtonText: 'I Agree',
       cancelButtonText: 'Never mind',
-    }).then((result) => {
+    }).then(async (result) => {
       if (result.value) {
-        const deleted = this.deleteFile(file);
+        const deleted = await this.deleteFile(file);
 
         if (deleted) {
           const mFiles = get(this, 'args.previouslyUploadedFiles');

--- a/app/components/workflow-files/index.js
+++ b/app/components/workflow-files/index.js
@@ -115,6 +115,7 @@ export default class WorkflowFiles extends Component {
       this.args.newFiles.pushObject(newFile);
     } catch (error) {
       FileUpload.file.state = 'aborted';
+      console.error(error);
     }
 
     return true;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,6 +1,6 @@
 import { camelize } from '@ember/string';
 import { discoverEmberDataModels } from 'ember-cli-mirage';
-import { createServer, JSONAPISerializer } from 'miragejs';
+import { createServer, JSONAPISerializer, Response } from 'miragejs';
 import doiJournals from './custom-fixtures/nih-submission/doi-journals';
 import schemas from './routes/schemas';
 import ENV from 'pass-ui/config/environment';
@@ -110,6 +110,9 @@ export default function (config) {
         const attrs = this.normalizedRequestAttrs();
 
         return schema.create('file', attrs);
+      });
+      this.delete('/data/file/:id/:name', (_schema, _request) => {
+        return new Response(200);
       });
 
       /** Schema Service */

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -100,6 +100,9 @@ export default function (config) {
           uuid: '12abc34xE999',
         };
       });
+      this.delete('/file/:id/:name', function (schema, request) {
+        return new Response(200);
+      });
       // File API
       this.get('/data/file', (schema, request) => {
         console.log(`[MirageJS] GET /file | query ${JSON.stringify(request.queryParams)}`);
@@ -111,8 +114,8 @@ export default function (config) {
 
         return schema.create('file', attrs);
       });
-      this.delete('/data/file/:id/:name', (_schema, _request) => {
-        return new Response(200);
+      this.delete('/data/file/:id', (_schema, _request) => {
+        return new Response(204);
       });
 
       /** Schema Service */

--- a/tests/integration/components/workflow-files-test.js
+++ b/tests/integration/components/workflow-files-test.js
@@ -173,16 +173,12 @@ module('Integration | Component | workflow files', (hooks) => {
       fileRole: 'manuscript',
     });
     file.destroyRecord = () => Promise.reject();
-    // Note: using Sinon to fake `deleteRecord` would result in an undefined error
-    // const deleteStub = sinon.replace(file, 'destroyRecord', sinon.fake.returns(Promise.reject()));
 
     this.previouslyUploadedFiles = [file];
 
     const flashMessages = this.owner.lookup('service:flash-messages');
     const flashMessagesFake = sinon.replace(flashMessages, 'danger', sinon.fake());
     this.flashMessages = flashMessages;
-
-    // this.owner.register('service:flash-messages', sinon.replace(flashMessages, 'danger', sinon.fake()));
 
     await render(hbs`
       <WorkflowFiles
@@ -205,7 +201,6 @@ module('Integration | Component | workflow files', (hooks) => {
     assert.ok(sweetAlertBtn);
     await click(sweetAlertBtn);
 
-    // assert.ok(deleteStub.calledOnce, 'File destroyRecord() should be called');
     assert.ok(flashMessagesFake.calledOnce, 'Flash message error should be called');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4031,9 +4031,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001449:
-  version "1.0.30001470"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz#09c8e87c711f75ff5d39804db2613dd593feeb10"
-  integrity sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==
+  version "1.0.30001581"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz"
+  integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Could use an eye on error handling.

Error handling in general is a bit of a mess in pass-ui, but specifically for file deletion, we want to try to handle error cases where the File entity could get into a weird state:
- Deletion of the file bytes has to be handled separately from removal of the File (metadata) entity in the database
- File entity has a URI reference to the bytes, pointing to where the file service can operate on the file
- Getting these two out of sync could be problematic in the Files step, submission review page, or submission details page

## Changes

- Provide custom File model adapter:
  - Call to `FIle.destroyRecord` will delete file bytes via the File Service before calling standard `destroyRecord` in the Ember store
- Update/add tests for `workflow-files` component