### PR TITLE
Submission deletion 

### DIFF
--- a/app/components/submission-action-cell/index.js
+++ b/app/components/submission-action-cell/index.js
@@ -7,6 +7,7 @@ import swal from 'sweetalert2';
 export default class SubmissionActionCell extends Component {
   @service currentUser;
   @service submissionHandler;
+  @service flashMessages;
 
   get isPreparer() {
     let userId = this.currentUser.user.id;
@@ -23,32 +24,32 @@ export default class SubmissionActionCell extends Component {
   }
 
   /**
-   * Delete the specified submission record from Fedora.
-   *
-   * Note: `ember-fedora-adapter#deleteRecord` behaves like `ember-data#destroyRecord`
-   * in that the deletion is pushed to the back end automatically, such that a
-   * subsequent 'save()' will fail.
+   * Delete the specified submission record. This is done via #destroyRecord
+   * so is immediately persisted
    *
    * @param {object} submission model object to be removed
    */
   @action
   deleteSubmission(submission) {
     swal({
-      // title: 'Are you sure?',
       text: 'Are you sure you want to delete this draft submission? This cannot be undone.',
       confirmButtonText: 'Delete',
       confirmButtonColor: '#DC3545',
       showCancelButton: true,
-      // buttonsStyling: false,
-      // confirmButtonClass: 'btn btn-danger',
-      // cancelButtonText: 'No',
-      // customClass: {
-      //   confirmButton: 'btn btn-danger'
-      // }
     }).then((result) => {
       if (result.value) {
-        this.submissionHandler.deleteSubmission(submission);
+        this.do_delete(submission);
       }
     });
+  }
+
+  async do_delete(submission) {
+    try {
+      await this.submissionHandler.deleteSubmission(submission);
+    } catch (e) {
+      this.flashMessages.danger(
+        'We encountered an error deleting this draft submission. Please try again later or contact your administrator'
+      );
+    }
   }
 }

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -474,10 +474,17 @@ export default class SubmissionsDetail extends Controller {
     if (result.value) {
       const ignoreList = this.searchHelper;
 
-      await this.submissionHandler.deleteSubmission(submission);
-      ignoreList.clearIgnore();
-      ignoreList.ignore(submission.get('id'));
-      this.transitionToRoute('submissions');
+      try {
+        await this.submissionHandler.deleteSubmission(submission);
+
+        ignoreList.clearIgnore();
+        ignoreList.ignore(submission.get('id'));
+        this.transitionToRoute('submissions');
+      } catch (e) {
+        this.flashMessages.danger(
+          'We encountered an error deleting this draft submission. Please try again later or contact your administrator'
+        );
+      }
     }
   }
 }

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -2,6 +2,7 @@ import CheckSessionRoute from '../check-session-route';
 import { inject as service } from '@ember/service';
 import { set } from '@ember/object';
 import { hash } from 'rsvp';
+import { fileForSubmissionQuery } from '../../util/paginated-query';
 
 export default class NewRoute extends CheckSessionRoute {
   @service('workflow')
@@ -64,13 +65,7 @@ export default class NewRoute extends CheckSessionRoute {
         sort: '+performedDate',
       });
 
-      files = this.store
-        .query('file', {
-          filter: {
-            file: `submission.id==${newSubmission.get('id')}`,
-          },
-        })
-        .then((files) => [...files.toArray()]);
+      files = this.store.query('file', fileForSubmissionQuery(newSubmission.id)).then((files) => [...files.toArray()]);
 
       // Also seed workflow.doiInfo with metadata from the Submission
       const metadata = newSubmission.get('metadata');

--- a/app/util/paginated-query.js
+++ b/app/util/paginated-query.js
@@ -1,4 +1,8 @@
 /**
+ * Centralizing JSON-API queries are formatted using RSQL, which can be a bit awkward to write.
+ */
+
+/**
  * Paginated query for the submissions/index route
  *
  * @param {object} params url query params
@@ -101,6 +105,22 @@ export function grantsIndexSubmissionQuery(user) {
   return {
     filter: {
       submission: `submissionStatus=out=cancelled;(${userMatch})`,
+    },
+  };
+}
+
+export function fileForSubmissionQuery(submissionId) {
+  return {
+    filter: {
+      file: `submission.id==${submissionId}`,
+    },
+  };
+}
+
+export function submissionsWithPublicationQuery(publication) {
+  return {
+    filter: {
+      submission: `publication.id==${publication.id}`,
     },
   };
 }

--- a/tests/unit/controllers/submissions/detail-test.js
+++ b/tests/unit/controllers/submissions/detail-test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Sinon from 'sinon';
 
 module('Unit | Controller | submissions/detail', (hooks) => {
   setupTest(hooks);
@@ -37,5 +38,31 @@ module('Unit | Controller | submissions/detail', (hooks) => {
     controller.set('transitionToRoute', () => assert.ok(true));
 
     controller.send('deleteSubmission', submission);
+  });
+
+  test('error message shown on submission deletion error', async function (assert) {
+    const submission = {};
+
+    // Mock global SweetAlert. Mocks a user clicking OK on the popup
+    swal = Sinon.fake.resolves({ value: true });
+
+    const controller = this.owner.lookup('controller:submissions/detail');
+    const transitionFake = Sinon.replace(controller, 'transitionToRoute', Sinon.fake());
+
+    controller.submissionHandler = this.owner.lookup('service:submission-handler');
+    const deleteFake = Sinon.replace(controller.submissionHandler, 'deleteSubmission', Sinon.fake.rejects());
+
+    controller.flashMessages = this.owner.lookup('service:flash-messages');
+    const flashFake = Sinon.replace(controller.flashMessages, 'danger', Sinon.fake());
+
+    // Note: using controller.send resolves immediately
+    // making subsequent assertions evaluate before the controller action fires
+    // Can't really use Sinon in a nice way unless we call the controller
+    // method directly
+    await controller.deleteSubmission(submission);
+
+    assert.ok(deleteFake.calledOnce, 'Submission handler delete should be called');
+    assert.ok(flashFake.calledOnce, 'Flash message should be called');
+    assert.equal(transitionFake.callCount, 0, 'Transition should not be called');
   });
 });

--- a/tests/unit/services/submission-handler-test.js
+++ b/tests/unit/services/submission-handler-test.js
@@ -447,7 +447,7 @@ module('Unit | Service | submission-handler', (hooks) => {
           // Get files for the submission
           return Promise.resolve(files);
         case 'submission':
-          return Promise.resolve([submission]);
+          return Promise.resolve([]);
         default:
           return Promise.reject();
       }


### PR DESCRIPTION
Related: https://github.com/eclipse-pass/main/issues/549

pass-core PR: https://github.com/eclipse-pass/pass-core/pull/81

Will require some pass-core changes to add delete permissions on appropriate objects

## Changes
- Update submission delete logic:
  - Delete Files on a draft submission
  - Delete Publication when possible
  - Finally, delete the Submission
  - Errors either thrown directly or passed
- Update `submission-action-cell` which has a Delete button
  - Add flash message on submission deletion error instead of relying on default error handling
- Update submission deletion logic in submission details page to show a flash message on submission deletion error
  - Normalize behavior to match behavior with submission-action-cell