### PR TITLE
Force config loading at application root

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -23,8 +23,12 @@ export default class ApplicationRoute extends CheckSessionRoute {
    * If there is a userToken query parameter call the user service with that parameter
    * to ensure objects are updated in the backend before any queries are done.
    */
-  beforeModel(transition) {
+  async beforeModel(transition) {
     let userToken = transition.to.queryParams.userToken;
+
+    if (!this.staticConfig.config) {
+      await this.staticConfig.setupStaticConfig();
+    }
 
     if (userToken) {
       return fetch(`/user/whoami?userToken=${encodeURIComponent(userToken)}`);
@@ -38,10 +42,6 @@ export default class ApplicationRoute extends CheckSessionRoute {
     const loader = document.getElementById('initial-loader');
     if (loader) {
       loader.style.display = 'none';
-    }
-
-    if (!this.staticConfig.config) {
-      await this.staticConfig.setupStaticConfig();
     }
   }
 }

--- a/app/routes/check-session-route.js
+++ b/app/routes/check-session-route.js
@@ -36,6 +36,7 @@ export default class CheckSessionRouteRoute extends Route {
 
   @action
   async error(error, transition) {
+    console.error(error);
     const errorObject = error?.errors?.firstObject || {};
 
     if ([401, 403].includes(Number(errorObject.status))) {

--- a/tests/acceptance/app-test.js
+++ b/tests/acceptance/app-test.js
@@ -1,0 +1,27 @@
+/* eslint-disable ember/no-classic-classes, ember/prefer-ember-test-helpers, ember/require-valid-css-selector-in-test-helpers */
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import sharedScenario from '../../mirage/scenarios/shared';
+
+module('Acceptance | application', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    await authenticateSession({ user: { id: '0' } });
+  });
+
+  test('Make sure app loads outside of root', async function (assert) {
+    sharedScenario(this.server);
+
+    await visit('/app/submissions');
+
+    assert.dom('.lds-dual-ring').doesNotExist('Loading spinner should not be present');
+
+    assert.dom('h1').exists();
+    assert.dom('h1').includesText('Submission');
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/eclipse-pass/main/issues/929

# Changes

- Move static config loading from `afterModel` hook to `beforeModel` hook
  - Force waiting for this to resolve before proceeding with any/all routes to avoid errors in those routes when trying to access the config
- Add basic regression test to make sure routes outside of root load directly
- Also add a `console.error` to dump error messages into JS console in browser on route/model hook errors
  - The error case presented by this bug should at least be dumped into the browser console with this

# Testing

- You'd need to create a local build of this branch of `pass-ui`
  - The included `build.sh` can help: `> ./build.sh <path_to_pass-docker>/.env`
  - This will produce a new Docker image: `ghcr.io/eclipse-pass/pass-ui:latest`
- In `eclipse-pass.local.yml` in `pass-docker`, update the image ref to use the `latest` tag that you just built
- Bring services in pass-docker up as normal
- Navigate to `pass.local` and go through the regular login process
- Click into the Submissions page (`/app/submissions`)
- Refresh the page
- The page should load as expected
  - Previously, this refresh would hang permanently with a loading spinner and never resolve