### PR TITLE
refactor: don't call authenticate on every visit to check session

### DIFF
--- a/app/routes/check-session-route.js
+++ b/app/routes/check-session-route.js
@@ -12,21 +12,12 @@ export default class CheckSessionRouteRoute extends Route {
   errorHandler;
 
   async beforeModel() {
-    // TODO: it is not ideal to have env checks in app code so it would be
-    // great to find another way to authenticate users in the development env
-    // with mirage at play. Note, we could direct people to go to the auth-callback
-    // route which would achieve a similar effect.
-    if (ENV.environment === 'development' && ENV['ember-cli-mirage']) {
+    if (!this.session.isAuthenticated) {
       await this.session.authenticate('authenticator:http-only');
     }
 
     if (!this.currentUser.user) {
       await this._loadCurrentUser();
-    }
-
-    if (!this.session.isAuthenticated) {
-      this.session.set('attemptedTransition', transition);
-      await this.session.invalidate();
     }
   }
 


### PR DESCRIPTION
- The UI was sending a request to whoami on every route visit
- This avoids that by only authenticating if a session doesn't already exist