### PR TITLE
Update gh workflows for complete release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,5 @@
-name: CI
-
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'main'
-    tags-ignore:
-      - '*'
-  pull_request: {}
+name: Continuous Integration
+on: [pull_request, workflow_dispatch]
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}

--- a/.github/workflows/update-docker-image.yml
+++ b/.github/workflows/update-docker-image.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    if:  github.event.pull_request.merged == true && github.repository == 'eclipse-pass/pass-ui'
+    if:  github.repository == 'eclipse-pass/pass-ui' && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/update-docker-image.yml
+++ b/.github/workflows/update-docker-image.yml
@@ -2,15 +2,13 @@ name: Update UI Docker image
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - 'main'
-    tags-ignore:
-      - '*'
+  pull_request:
+    types:
+      - closed
 
 jobs:
   build:
-    if:  github.repository == 'eclipse-pass/pass-ui'
+    if:  github.event.pull_request.merged == true && github.repository == 'eclipse-pass/pass-ui'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Needed for complete workflow fixes PR: https://github.com/eclipse-pass/main/pull/983

Updated ci workflow to trigger on same events as pass-core/pass-support.

Changed update docker images workflow to trigger on PR merge.