### PR TITLE
Handle CSRF tokens

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -2,6 +2,7 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { camelize } from '@ember/string';
 import ENV from 'pass-ui/config/environment';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
 /**
  * PASS specific extensions for Ember Data's JSON:API adapter
@@ -11,9 +12,12 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 
   namespace = ENV.passApi.namespace;
 
-  headers = {
-    withCredentials: true,
-  };
+  get headers() {
+    return {
+      withCredentials: true,
+      'X-XSRF-TOKEN': document.cookie.match(/XSRF-TOKEN\=([^;]*)/)['1'],
+    };
+  }
 
   // Camel case instead of pluralize model types for our API
   pathForType(type) {

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -2,7 +2,6 @@ import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { camelize } from '@ember/string';
 import ENV from 'pass-ui/config/environment';
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
 
 /**
  * PASS specific extensions for Ember Data's JSON:API adapter

--- a/app/adapters/file.js
+++ b/app/adapters/file.js
@@ -22,6 +22,10 @@ export default class FileAdapter extends ApplicationAdapter {
     }
     return fetch(url, {
       method: 'DELETE',
+      credentials: 'same-origin',
+      headers: {
+        'X-XSRF-TOKEN': document.cookie.match(/XSRF-TOKEN\=([^;]*)/)['1'],
+      },
     }).then((response) => {
       if (!response.ok) {
         throw new Error('Delete request to the file service failed');

--- a/app/components/workflow-files/index.js
+++ b/app/components/workflow-files/index.js
@@ -97,7 +97,12 @@ export default class WorkflowFiles extends Component {
   @action
   async uploadFile(FileUpload) {
     try {
-      const response = await FileUpload.upload(ENV.fileServicePath);
+      const response = await FileUpload.upload(ENV.fileServicePath, {
+        withCredentials: true,
+        headers: {
+          'X-XSRF-TOKEN': document.cookie.match(/XSRF-TOKEN\=([^;]*)/)['1'],
+        },
+      });
 
       const file = await response.json();
 

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -32,6 +32,7 @@ export default class DoiService extends Service {
       headers: {
         Accept: 'application/json; charset=utf-8',
         withCredentials: 'include',
+        'X-XSRF-TOKEN': document.cookie.match(/XSRF-TOKEN\=([^;]*)/)['1'],
       },
     });
 

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -15,3 +15,6 @@ setupSinon();
 setup(QUnit.assert);
 
 start();
+
+// Set a fake CSRF token
+document.cookie = 'XSRF-TOKEN=moo';


### PR DESCRIPTION
Put CSRF tokens from cookies into headers.

This requires all the prs mentioned in https://github.com/eclipse-pass/pass-core/pull/90 in order to test.
Without the other prs the unit tests will succeed, but the acceptance tests will fail.
