### PR TITLE
fix: use default ember test scripts in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
       - name: Run Tests
-        run: pnpm run test:no-serve
+        run: pnpm run test
 
   acceptance-test:
     name: "Acceptance test"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember server",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
-    "test:no-serve": "ember test",
-    "test:serve": "ember test -s",
+    "test:ember": "ember test",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
- this fixes an issue with concurrently where both the noserve and serve scripts were being run at the same time causing an error when we switched to pnpm
- the default setup in ember is what this PR proposes