### PR TITLE
fix: show manuscripts for doi if returned

### DIFF
--- a/app/components/found-manuscripts/index.js
+++ b/app/components/found-manuscripts/index.js
@@ -46,7 +46,7 @@ export default class FoundManuscriptsComponent extends Component {
     const foundOAMss = yield this.oaManuscriptService.lookup(doi);
 
     if (foundOAMss) {
-      this.foundManuscripts.push(foundOAMss);
+      this.foundManuscripts = [...foundOAMss];
     }
   };
 }

--- a/app/services/oa-manuscript-service.js
+++ b/app/services/oa-manuscript-service.js
@@ -23,7 +23,7 @@ export default class OAManuscriptService extends Service {
     console.assert(!!doi, '%cNo DOI was provided to the manuscript service lookup.', 'color: red;');
 
     if (!this.lookUpPath || !doi) {
-      return;
+      return [];
     }
 
     const url = `${this.lookUpPath}?doi=${doi}`;
@@ -38,7 +38,7 @@ export default class OAManuscriptService extends Service {
       .then((resp) => {
         if (resp.status !== 200) {
           console.log(`%cFailed to lookup files for DOI (${doi}). Reason: "${resp.message}"`, 'color: red;');
-          return {};
+          return [];
         }
         return resp.json();
       })

--- a/tests/integration/components/found-manuscripts/component-test.js
+++ b/tests/integration/components/found-manuscripts/component-test.js
@@ -47,10 +47,12 @@ module('Integration | Component | found-manuscripts', (hooks) => {
     const mockMsService = Service.extend({
       lookup(doi) {
         assert.ok(doi, 'DOI needs to be present');
-        return Promise.resolve({
-          name: 'This is a moo',
-          url: 'http://moo.example.com',
-        });
+        return Promise.resolve([
+          {
+            name: 'This is a moo',
+            url: 'http://moo.example.com',
+          },
+        ]);
       },
     });
 


### PR DESCRIPTION
This PR fixes an assignment bug in the DOI manuscript component.  Manuscript objects are returned in an array from the service, so assigning instead of pushing to `foundManuscripts` is needed.