### PR TITLE
Add deposit status message to deposit status tooltip

### DIFF
--- a/app/components/submission-repo-details/index.js
+++ b/app/components/submission-repo-details/index.js
@@ -39,6 +39,7 @@ export default class SubmissionRepoDetails extends Component {
    * Return a tooltip based on the current status.
    */
   get tooltip() {
+    const depositStatusMsg = this.args.deposit?.statusMessage ? ` Message: ${this.args.deposit.statusMessage}.` : '';
     switch (this.status) {
       case 'complete':
         return 'Submission was accepted and processed by the repository. ID(s) have been assigned to the submitted manuscript.';
@@ -49,7 +50,7 @@ export default class SubmissionRepoDetails extends Component {
       case 'manuscript-required':
         return 'Your funder is aware of this publication and is expecting the deposit of your manuscript.';
       case 'failed':
-        return 'The system failed to receive the files for this submission. Please try again by starting a new submission';
+        return `The system failed to receive the files for this submission.${depositStatusMsg} Please try again by starting a new submission`;
       case 'rejected':
         return 'This target repository has rejected your submission. Please contact us for more details or try to submit your manuscript again.';
       case 'not-submitted':

--- a/app/models/deposit.js
+++ b/app/models/deposit.js
@@ -3,6 +3,7 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class DepositModel extends Model {
   @attr('string') depositStatusRef;
   @attr('string') depositStatus;
+  @attr('string') statusMessage;
 
   @belongsTo('repositoryCopy', { async: false, inverse: null }) repositoryCopy;
   @belongsTo('submission', { async: false, inverse: null }) submission;

--- a/tests/integration/components/submission-repo-details-test.js
+++ b/tests/integration/components/submission-repo-details-test.js
@@ -1,3 +1,4 @@
+import EmberObject from '@ember/object';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
@@ -13,5 +14,31 @@ module('Integration | Component | submission repo details', (hooks) => {
     // Template usage:
     await render(hbs`<SubmissionRepoDetails />`);
     assert.ok(true);
+  });
+
+  test('renders deposit status message when present on failed', async function (assert) {
+    this.set('submission', EmberObject.create({ submitted: true }));
+    this.set('deposit', EmberObject.create({ depositStatus: 'failed', statusMessage: 'test-status-message' }));
+
+    await render(hbs`<SubmissionRepoDetails @deposit={{this.deposit}} @submission={{this.submission}} />`);
+    assert
+      .dom('span.failed')
+      .hasAttribute(
+        'tooltip',
+        'The system failed to receive the files for this submission. Message: test-status-message. Please try again by starting a new submission',
+      );
+  });
+
+  test('does not render deposit status message when not present on failed', async function (assert) {
+    this.set('submission', EmberObject.create({ submitted: true }));
+    this.set('deposit', EmberObject.create({ depositStatus: 'failed' }));
+
+    await render(hbs`<SubmissionRepoDetails @deposit={{this.deposit}} @submission={{this.submission}} />`);
+    assert
+      .dom('span.failed')
+      .hasAttribute(
+        'tooltip',
+        'The system failed to receive the files for this submission. Please try again by starting a new submission',
+      );
   });
 });


### PR DESCRIPTION
If the deposit status is failed and `deposit.statusMessage` is defined, it will be included in the Deposit Status tooltip message.