### PR TITLE
Add Guides and License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ A full list of all the Eclipse PASS projects can be found in the PASS Main repos
 
 # License
 
-PASS Core is Open Source software released under the [Apache 2.0 license](LICENSE).
+PASS UI is Open Source software released under the [Apache 2.0 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PASS UI
+# PASS UI ![Pass Core](https://github.com/eclipse-pass/pass-ui/actions/workflows/ci.yml/badge.svg)
 
 PASS UI is the user interface component of the PASS application, developed using the Ember.js framework. It connects 
 with PASS Core via an Elide-based API to display and manage data related to submissions, repositories, policies, and 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PASS UI ![Pass Core](https://github.com/eclipse-pass/pass-ui/actions/workflows/ci.yml/badge.svg)
+# PASS UI ![Pass UI](https://github.com/eclipse-pass/pass-ui/actions/workflows/ci.yml/badge.svg)
 
 PASS UI is the user interface component of the PASS application, developed using the Ember.js framework. It connects 
 with PASS Core via an Elide-based API to display and manage data related to submissions, repositories, policies, and 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ users. PASS UI streamlines the submission process, guiding users through creatin
 submissions while ensuring compliance with funder and institutional policies. Its design emphasizes ease of use, 
 enabling researchers to navigate the scholarly deposit process with minimal friction.
 
-You can find further documentation and details about [PASS UI](https://docs.eclipse-pass.org/developer-documentation/pass-ui)
-on the [full documentation site](https://docs.eclipse-pass.org). A full list of all the Eclipse PASS projects can also
-be found in the PASS Main repository [README](https://github.com/eclipse-pass/main/blob/main/README.md).
+A full list of all the Eclipse PASS projects can be found in the PASS Main repository [README](https://github.com/eclipse-pass/main).
+
+# Guides
+
+* [PASS UI Documentation](https://docs.eclipse-pass.org/developer-documentation/pass-ui)
+* [PASS Documentation](https://docs.eclipse-pass.org/)
+
+# License
+
+PASS Core is Open Source software released under the [Apache 2.0 license](LICENSE).


### PR DESCRIPTION
This PR adds the Guides and License sections in the pass-ui repository top level README.

Related to https://github.com/eclipse-pass/main/pull/1081. When merged PR 1081 will close the https://github.com/eclipse-pass/main/issues/1035; however these PRs can be merged in any order.