### PR TITLE
Set USER in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.22.0-alpine
+FROM nginxinc/nginx-unprivileged:1.27.3-alpine
 
 ARG EMBER_ROOT_URL
 ARG USER_SERVICE_URL
@@ -19,14 +19,19 @@ ENV USER_SERVICE_URL=${USER_SERVICE_URL:-/pass-user-service/whoami} \
     STATIC_CONFIG_URL=${STATIC_CONFIG_URL:-/app/config.json} \
     PASS_UI_PORT=80
 
+USER root
+
 COPY .docker/bin/entrypoint.sh /bin/
 COPY .docker/nginx-template.conf /
+COPY ./pass-ui-*-cyclonedx-sbom.json /
+COPY ./dist/ /usr/share/nginx/html/app/
 
 RUN apk --no-cache add gettext && \
     chmod a+x /bin/entrypoint.sh && \
-    mkdir /usr/share/nginx/html/app
+    chown nginx:nginx /bin/entrypoint.sh && \
+    chown nginx:nginx /nginx-template.conf && \
+    chown -R nginx:nginx /usr/share/nginx/html/app
 
-COPY ./dist/ /usr/share/nginx/html/app/
-COPY ./pass-ui-*-cyclonedx-sbom.json /
+USER nginx
 
 ENTRYPOINT [ "/bin/entrypoint.sh" ]


### PR DESCRIPTION
This PR updates the Dockerfile so the pass-ui docker container runs with the non-privileged nginx user.

Note that the base image was changed to nginxinc/nginx-unprivileged:1.27.3-alpine.  This is what I found was the suggested way for running the nginx docker container with a non-privileged user. (https://hub.docker.com/_/nginx Running nginx as a non-root user).  Also note the upgrade in nginx version to 1.27.3.

I have tested this locally in pass-docker and acceptance tests pass.  I also tested the config where custom branding is mounted.  L&F changed and tests passed.