### PR TITLE
Fix publication date parsing of doi metadata 

### DIFF
--- a/app/components/workflow-metadata/index.js
+++ b/app/components/workflow-metadata/index.js
@@ -141,7 +141,7 @@ export default class WorkflowMetadata extends Component {
         target: ENV.APP.rootElement,
         type: 'error',
         title: 'Form Validation Error',
-        html: this.validationErrorMsg(metadataSchema.getErrors()),
+        html: metadataSchema.getErrorMessage(),
       });
       return;
     }

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -149,7 +149,7 @@ export default class DoiService extends Service {
     }
     if (doiCopy.issued && doiCopy.issued['date-parts']) {
       const parts = doiCopy.issued['date-parts'];
-      doiCopy.publicationDate = parts.flat().join('-');
+      doiCopy.publicationDate = new Date(parts).toISOString().replace(/T.*/, '');
     }
 
     doiCopy.doi = doiCopy.DOI;

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -118,7 +118,7 @@ export default class MetadataSchemaService extends Service {
 
     if (readonly && readonly.length > 0) {
       /**
-       * For each key in the data object, if they are marked as "read only",
+       * For each key in the data object, if they are marked as "read only"
        * set the field's 'readonly' to true, and 'toolbarSticky' to false iff the
        * key refers to an array
        */
@@ -181,6 +181,41 @@ export default class MetadataSchemaService extends Service {
 
   getErrors() {
     return this.validator.errors;
+  }
+
+  /**
+   * Turn a property returned by something like Ajv into its title.
+   * Ideally this would be looked up in the schema instead, but the general case is complicated.
+   */
+  getPropertyTitle(property) {
+    // ab-cd -> abCd
+    let title = property.replace(/-\w/g, (s) => s.charAt(1).toUpperCase());
+
+    // Clean out non-word characters
+    title = property.replace(/\W/g, '');
+
+    // Turn into words
+    title = title.replace(/[A-Z]/g, (s) => ' ' + s).trim();
+
+    // Capitalize first word
+    title = title.charAt(0).toUpperCase() + title.slice(1);
+
+    return title;
+  }
+
+  /**
+   * Return a human readable message describing validation errorss.
+   */
+  getErrorMessage() {
+    return this.validator.errors
+      .map((error) => {
+        if (error.keyword === 'required') {
+          return 'Missing required metadata: ' + this.getPropertyTitle(error.params.missingProperty);
+        } else {
+          return error.message;
+        }
+      })
+      .join(', ');
   }
 
   /**

--- a/tests/acceptance/nih-submission-test.js
+++ b/tests/acceptance/nih-submission-test.js
@@ -453,7 +453,7 @@ module('Acceptance | submission', function (hooks) {
     await click('.alpaca-form-button-Next');
 
     await waitFor('#swal2-content');
-    assert.dom('#swal2-content').includesText("should have required property 'author'");
+    assert.dom('#swal2-content').includesText('Missing required metadata: Author');
 
     // Some reason, setting the document query to a variable before clicking works,
     // but calling the query selector in the click does not work
@@ -592,7 +592,7 @@ module('Acceptance | submission', function (hooks) {
     await click('.alpaca-form-button-Next');
 
     await waitFor('#swal2-content');
-    assert.dom('#swal2-content').includesText("should have required property 'author'");
+    assert.dom('#swal2-content').includesText('Missing required metadata: Author');
 
     const confirmBtn = '.swal2-confirm';
     assert.ok(confirmBtn, 'No SweetAlert OK button found');


### PR DESCRIPTION
The publication date formatting stored in the metadata must match what is expected by the data picker.
The error messages about missing metadata are now better formatted.

I was worried about  the publication date not being editable if it is not in the doi metadata since it is required. But despite it not seeming to be required, it is on every DOI I look at. And making a change so that missing values are editable also might be problematic.
