### PR TITLE
Upgrade sweetalert2 and remove unsafe-inline requirement

### DIFF
--- a/app/components/external-repo-review/index.js
+++ b/app/components/external-repo-review/index.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import ENV from 'pass-ui/config/environment';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 
 class VisitableRepo {
   @tracked visited;
@@ -47,26 +48,25 @@ export default class ExternalRepoReviewComponent extends Component {
 
   @action
   openWeblinkAlert(repo) {
-    swal({
-      target: ENV.APP.rootElement,
-      title: 'Notice!',
-      text: 'You are being sent to an external site. This will open a new tab.',
-      showCancelButton: true,
-      cancelButtonText: 'Cancel',
-      confirmButtonText: 'Open new tab',
-    }).then((value) => {
-      if (value.dismiss) {
-        return; // Don't redirect
-      }
-
-      $('#externalSubmission').modal('hide');
-
-      const win = window.open(repo.url, '_blank');
-      if (win) {
-        win.focus();
-      }
-
-      this.handleRepo(repo);
-    });
+    swal
+      .fire({
+        target: ENV.APP.rootElement,
+        title: 'Notice!',
+        text: 'You are being sent to an external site. This will open a new tab.',
+        showCancelButton: true,
+        cancelButtonText: 'Cancel',
+        confirmButtonText: 'Open new tab',
+      })
+      .then((value) => {
+        if (value.dismiss) {
+          return; // Don't redirect
+        }
+        $('#externalSubmission').modal('hide');
+        const win = window.open(repo.url, '_blank');
+        if (win) {
+          win.focus();
+        }
+        this.handleRepo(repo);
+      });
   }
 }

--- a/app/components/submission-action-cell/index.js
+++ b/app/components/submission-action-cell/index.js
@@ -2,7 +2,7 @@
 import { action, get } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-import swal from 'sweetalert2';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 import ENV from 'pass-ui/config/environment';
 
 export default class SubmissionActionCell extends Component {
@@ -32,17 +32,19 @@ export default class SubmissionActionCell extends Component {
    */
   @action
   deleteSubmission(submission) {
-    swal({
-      target: ENV.APP.rootElement,
-      text: 'Are you sure you want to delete this draft submission? This cannot be undone.',
-      confirmButtonText: 'Delete',
-      confirmButtonColor: '#DC3545',
-      showCancelButton: true,
-    }).then((result) => {
-      if (result.value) {
-        this.do_delete(submission);
-      }
-    });
+    swal
+      .fire({
+        target: ENV.APP.rootElement,
+        text: 'Are you sure you want to delete this draft submission? This cannot be undone.',
+        confirmButtonText: 'Delete',
+        confirmButtonColor: '#DC3545',
+        showCancelButton: true,
+      })
+      .then((result) => {
+        if (result.value) {
+          this.do_delete(submission);
+        }
+      });
   }
 
   async do_delete(submission) {

--- a/app/components/workflow-basics/index.js
+++ b/app/components/workflow-basics/index.js
@@ -8,6 +8,7 @@ import { task, timeout } from 'ember-concurrency';
 import { scheduleOnce } from '@ember/runloop';
 import { dropTask } from 'ember-concurrency-decorators';
 import ENV from 'pass-ui/config/environment';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 
 const DEBOUNCE_MS = 250;
 
@@ -197,9 +198,9 @@ export default class WorkflowBasics extends Component {
   async changeSubmitter(isProxySubmission, submitter) {
     let hasGrants = get(this, 'submission.grants') && get(this, 'submission.grants.length') > 0;
     if (hasGrants) {
-      let result = swal({
+      let result = swal.fire({
         target: ENV.APP.rootElement,
-        type: 'warning',
+        icon: 'warning',
         title: 'Are you sure?',
         html: 'Changing the submitter will also <strong>remove any grants</strong> currently attached to your submission. Are you sure you want to proceed?',
         showCancelButton: true,

--- a/app/components/workflow-files/index.js
+++ b/app/components/workflow-files/index.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency-decorators';
 import ENV from 'pass-ui/config/environment';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 
 export default class WorkflowFiles extends Component {
   @service store;
@@ -49,35 +50,35 @@ export default class WorkflowFiles extends Component {
 
   @action
   deleteExistingFile(file) {
-    swal({
-      target: ENV.APP.rootElement,
-      title: 'Are you sure?',
-      text: 'If you delete this file, it will be gone forever.',
-      type: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#3085d6',
-      cancelButtonColor: '#d33',
-      confirmButtonText: 'I Agree',
-      cancelButtonText: 'Never mind',
-    }).then(async (result) => {
-      if (result.value) {
-        const deleted = await this.deleteFile(file);
-
-        if (deleted) {
-          const mFiles = this.args.previouslyUploadedFiles;
-          // Remove the file from the model
-          if (mFiles) {
-            this.args.updatePreviouslyUploadedFiles(mFiles.filter((f) => f.id !== file.id));
+    swal
+      .fire({
+        target: ENV.APP.rootElement,
+        title: 'Are you sure?',
+        text: 'If you delete this file, it will be gone forever.',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        confirmButtonText: 'I Agree',
+        cancelButtonText: 'Never mind',
+      })
+      .then(async (result) => {
+        if (result.value) {
+          const deleted = await this.deleteFile(file);
+          if (deleted) {
+            const mFiles = this.args.previouslyUploadedFiles;
+            // Remove the file from the model
+            if (mFiles) {
+              this.args.updatePreviouslyUploadedFiles(mFiles.filter((f) => f.id !== file.id));
+            }
+            const newFiles = this.args.newFiles;
+            if (newFiles) {
+              this.args.updateNewFiles(newFiles.filter((f) => f.id !== file.id));
+            }
+            document.querySelector('#file-multiple-input').value = null;
           }
-
-          const newFiles = this.args.newFiles;
-          if (newFiles) {
-            this.args.updateNewFiles(newFiles.filter((f) => f.id !== file.id));
-          }
-          document.querySelector('#file-multiple-input').value = null;
         }
-      }
-    });
+      });
   }
 
   @action

--- a/app/components/workflow-metadata/index.js
+++ b/app/components/workflow-metadata/index.js
@@ -2,9 +2,8 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import _ from 'lodash';
 import { inject as service } from '@ember/service';
-import swal from 'sweetalert2';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 import { task } from 'ember-concurrency-decorators';
 import ENV from 'pass-ui/config/environment';
 
@@ -137,9 +136,9 @@ export default class WorkflowMetadata extends Component {
       console.log('%cError(s) found while validating data', 'color:red;');
       console.log(metadataSchema.getErrors());
 
-      swal({
+      swal.fire({
         target: ENV.APP.rootElement,
-        type: 'error',
+        icon: 'error',
         title: 'Form Validation Error',
         html: metadataSchema.getErrorMessage(),
       });

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -5,6 +5,7 @@ import { action, get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import _ from 'lodash';
 import ENV from 'pass-ui/config/environment';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 
 export default class SubmissionsNew extends Controller {
   queryParams = ['grant', 'submission', 'covid'];
@@ -91,9 +92,13 @@ export default class SubmissionsNew extends Controller {
 
     const submitter = await this.userIsSubmitter();
     if (manuscriptFiles.length == 0 && submitter) {
-      swal('Manuscript Is Missing', 'At least one manuscript file is required.  Please go back and add one', 'warning');
+      swal.fire(
+        'Manuscript Is Missing',
+        'At least one manuscript file is required.  Please go back and add one',
+        'warning',
+      );
     } else if (manuscriptFiles.length > 1) {
-      swal(
+      swal.fire(
         'Incorrect Manuscript Count',
         `Only one file may be designated as the manuscript.  Instead, found ${manuscriptFiles.length}.  Please go back and edit the file list`,
         'warning',
@@ -134,7 +139,7 @@ export default class SubmissionsNew extends Controller {
     const submission = this.model.newSubmission;
     const ignoreList = this.searchHelper;
 
-    let result = await swal({
+    let result = await swal.fire({
       target: ENV.APP.rootElement,
       title: 'Discard Draft',
       text: "This will abort the current submission and discard progress you've made. This cannot be undone.",

--- a/app/controllers/submissions/new/files.js
+++ b/app/controllers/submissions/new/files.js
@@ -6,6 +6,7 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import _ from 'lodash';
 import ENV from 'pass-ui/config/environment';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 
 export default class SubmissionsNewFiles extends Controller {
   @service workflow;
@@ -84,11 +85,11 @@ export default class SubmissionsNewFiles extends Controller {
       const submitter = await this.parent.userIsSubmitter();
 
       if (manuscriptFiles.length == 0 && !submitter) {
-        let result = await swal({
+        let result = await swal.fire({
           target: ENV.APP.rootElement,
           title: 'No manuscript present',
           text: 'If no manuscript is attached, the designated submitter will need to add one before final submission',
-          type: 'warning',
+          icon: 'warning',
           showCancelButton: true,
           confirmButtonText: 'OK',
           cancelButtonText: 'Cancel',

--- a/app/controllers/submissions/new/repositories.js
+++ b/app/controllers/submissions/new/repositories.js
@@ -5,6 +5,7 @@ import { action, get, set } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import ENV from 'pass-ui/config/environment';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 
 export default class SubmissionsNewRepositories extends Controller {
   @service workflow;
@@ -50,9 +51,9 @@ export default class SubmissionsNewRepositories extends Controller {
   async validateAndLoadTab(gotoRoute) {
     let needValidation = this.needValidation;
     if (needValidation && get(this, 'submission.repositories.length') == 0) {
-      let value = await swal({
+      let value = await swal.fire({
         target: ENV.APP.rootElement,
-        type: 'warning',
+        icon: 'warning',
         title: 'No repositories selected',
         html:
           'If you don\'t plan on submitting to any repositories, you can stop at this time. Click "Exit ' +

--- a/app/index.html
+++ b/app/index.html
@@ -21,18 +21,14 @@
     <script src="{{rootURL}}assets/pass-ui.js"></script>
 
     <script type="text/javascript" src="{{rootURL}}js/fuzzyset.js"></script>
-    <script type="text/javascript" src="//code.jquery.com/jquery-3.6.4.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js"
       integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
       crossorigin="anonymous"
     ></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.8/handlebars.js"></script>
-    <script type="text/javascript" src="//code.cloudcms.com/alpaca/1.5.24/bootstrap/alpaca.min.js"></script>
-    <script
-      type="text/javascript"
-      src="https://cdn.jsdelivr.net/npm/sweetalert2@7.29.0/dist/sweetalert2.all.min.js"
-    ></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.8/handlebars.js"></script>
+    <script type="text/javascript" src="https://code.cloudcms.com/alpaca/1.5.24/bootstrap/alpaca.min.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/app/services/error-handler.js
+++ b/app/services/error-handler.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import ENV from 'pass-ui/config/environment';
+import swal from 'sweetalert2/dist/sweetalert2.js';
 
 // Consolidates error handling.
 // The method handleError will figure out which handler to invoke.
@@ -49,16 +50,18 @@ export default class ErrorHandlerService extends Service {
   }
 
   handleSessionTimeout(error) {
-    swal({
-      target: ENV.APP.rootElement,
-      type: 'error',
-      title: 'Your session timed out',
-      text: 'When you click OK the page will reload.',
-    }).then((result) => {
-      if (result.value) {
-        window.location.reload(true);
-      }
-    });
+    swal
+      .fire({
+        target: ENV.APP.rootElement,
+        icon: 'error',
+        title: 'Your session timed out',
+        text: 'When you click OK the page will reload.',
+      })
+      .then((result) => {
+        if (result.value) {
+          window.location.reload(true);
+        }
+      });
   }
 
   handleLoginFailure(error) {
@@ -75,32 +78,36 @@ export default class ErrorHandlerService extends Service {
   }
 
   handleDidNotLoadDataError(error) {
-    swal({
-      target: ENV.APP.rootElement,
-      type: 'error',
-      title: 'Page could not load',
-      text: `Some information required by this page did not load correctly. When you click OK the page will reload. If the issue persists, please contact us and include a copy of this message. ${JSON.stringify(
-        error.message,
-      )}`,
-    }).then((result) => {
-      if (result.value) {
-        window.location.reload(true);
-      }
-    });
+    swal
+      .fire({
+        target: ENV.APP.rootElement,
+        icon: 'error',
+        title: 'Page could not load',
+        text: `Some information required by this page did not load correctly. When you click OK the page will reload. If the issue persists, please contact us and include a copy of this message. ${JSON.stringify(
+          error.message,
+        )}`,
+      })
+      .then((result) => {
+        if (result.value) {
+          window.location.reload(true);
+        }
+      });
   }
 
   handleUnknownError(error) {
-    swal({
-      target: ENV.APP.rootElement,
-      type: 'error',
-      title: 'Something went wrong.',
-      text: `When you click OK the page will reload. If the issue persists, please contact us and include a copy of this message. ${JSON.stringify(
-        error.message,
-      )}`,
-    }).then((result) => {
-      if (result.value) {
-        window.location.reload(true);
-      }
-    });
+    swal
+      .fire({
+        target: ENV.APP.rootElement,
+        icon: 'error',
+        title: 'Something went wrong.',
+        text: `When you click OK the page will reload. If the issue persists, please contact us and include a copy of this message. ${JSON.stringify(
+          error.message,
+        )}`,
+      })
+      .then((result) => {
+        if (result.value) {
+          window.location.reload(true);
+        }
+      });
   }
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -622,18 +622,26 @@ table td {
   opacity: 1;
 }
 
+div:where(.swal2-container) button:where(.swal2-styled):where(.swal2-confirm):focus-visible {
+  box-shadow:
+    0 0 0 0.0625em #fff,
+    0 0 0 0.125em rgb(50 100 150 / 40%) !important;
+}
+
+div:where(.swal2-container) button:where(.swal2-styled):where(.swal2-cancel):focus-visible {
+  box-shadow:
+    0 0 0 0.0625em #fff,
+    0 0 0 0.125em rgb(50 100 150 / 40%) !important;
+}
+
 .swal2-confirm {
   display: inline-block;
-  font-weight: 400;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
   user-select: none;
-  border: 1px solid transparent;
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
   line-height: 1.5;
-  border-radius: 0;
+  padding: 0.625em 2em;
   /* stylelint-disable-next-line prettier/prettier */
   transition:
     color 0.15s ease-in-out,
@@ -643,21 +651,16 @@ table td {
   background-color: #418fde !important;
   border-color: #418fde !important;
   color: white !important;
-  margin: 0 5px;
 }
 
 .swal2-cancel {
   display: inline-block;
-  font-weight: 400;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
   user-select: none;
-  border: 1px solid transparent;
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
   line-height: 1.5;
-  border-radius: 0;
+  padding: 0.625em 2em;
   /* stylelint-disable-next-line prettier/prettier */
   transition:
     color 0.15s ease-in-out,
@@ -667,7 +670,6 @@ table td {
   color: #151b1e !important;
   background-color: #a4b7c1 !important;
   border-color: #a4b7c1 !important;
-  margin: 0 5px;
 }
 
 .nodata-placeholder {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -57,6 +57,7 @@ module.exports = function (defaults) {
 
   app.import('node_modules/ember-modal-dialog/app/styles/ember-modal-dialog/ember-modal-structure.css');
   app.import('node_modules/ember-modal-dialog/app/styles/ember-modal-dialog/ember-modal-appearance.css');
+  app.import('node_modules/sweetalert2/dist/sweetalert2.css');
 
   const { Webpack } = require('@embroider/webpack');
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jquery": "3.6.4",
     "loader.js": "^4.7.0",
     "popper.js": "^1.16.1",
-    "sweetalert2": "7.29.0"
+    "sweetalert2": "11.17.2"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^1.16.1
         version: 1.16.1
       sweetalert2:
-        specifier: 7.29.0
-        version: 7.29.0
+        specifier: 11.17.2
+        version: 11.17.2
     devDependencies:
       '@babel/core':
         specifier: ^7.24.7
@@ -7290,9 +7290,8 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
-  sweetalert2@7.29.0:
-    resolution: {integrity: sha512-QYMpgj+W1nmE5I6hQ+Kvj+xSAJ78o5oawNOm65fq+0DRuZqmNPwGNnyfMcA3/porpje6RjXJd41NCJN8Rj83wQ==}
-    engines: {node: '>=0.10.0'}
+  sweetalert2@11.17.2:
+    resolution: {integrity: sha512-HKxDr1IyV3Lxr3W6sb61qm/p2epFIEdr5EKwteRFHnIg6f8nHFl2kX++DBVz16Mac+fFiU3hMpjq1L6yE2Ge5w==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -17866,7 +17865,7 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  sweetalert2@7.29.0: {}
+  sweetalert2@11.17.2: {}
 
   symbol-tree@3.2.4: {}
 

--- a/tests/acceptance/nih-submission-test.js
+++ b/tests/acceptance/nih-submission-test.js
@@ -452,8 +452,8 @@ module('Acceptance | submission', function (hooks) {
 
     await click('.alpaca-form-button-Next');
 
-    await waitFor('#swal2-content');
-    assert.dom('#swal2-content').includesText('Missing required metadata: Author');
+    await waitFor('#swal2-html-container');
+    assert.dom('#swal2-html-container').includesText('Missing required metadata: Author');
 
     // Some reason, setting the document query to a variable before clicking works,
     // but calling the query selector in the click does not work
@@ -591,8 +591,8 @@ module('Acceptance | submission', function (hooks) {
 
     await click('.alpaca-form-button-Next');
 
-    await waitFor('#swal2-content');
-    assert.dom('#swal2-content').includesText('Missing required metadata: Author');
+    await waitFor('#swal2-html-container');
+    assert.dom('#swal2-html-container').includesText('Missing required metadata: Author');
 
     const confirmBtn = '.swal2-confirm';
     assert.ok(confirmBtn, 'No SweetAlert OK button found');

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -252,7 +252,7 @@ module('Integration | Component | workflow-metadata', (hooks) => {
     await waitFor('.swal2-confirm');
 
     assert.dom('.swal2-title').includesText('Form Validation Error');
-    assert.dom('.swal2-content').includesText('should be string');
+    assert.dom('.swal2-html-container').includesText('should be string');
     await click('.swal2-confirm');
   });
 

--- a/tests/integration/components/workflow-review-test.js
+++ b/tests/integration/components/workflow-review-test.js
@@ -165,8 +165,8 @@ module('Integration | Component | workflow review', (hooks) => {
 
     await click('.swal2-confirm');
 
-    await waitFor('.swal2-validationerror');
-    assert.dom('.swal2-validationerror').containsText('You need to choose something!');
+    await waitFor('.swal2-validation-message');
+    assert.dom('.swal2-validation-message').containsText('You need to choose something!');
 
     await waitFor('.swal2-container');
     await click('.swal2-container');
@@ -372,7 +372,7 @@ module('Integration | Component | workflow review', (hooks) => {
 
     // Should be warning about no deposit agreement
     assert.dom('.swal2-title').includesText('Your submission cannot be submitted.');
-    assert.dom('.swal2-content').includesText(repo1.name);
+    assert.dom('.swal2-html-container').includesText(repo1.name);
 
     await click('.swal2-confirm');
 

--- a/tests/unit/controllers/submissions/detail-test.js
+++ b/tests/unit/controllers/submissions/detail-test.js
@@ -2,6 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Sinon from 'sinon';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
 
 module('Unit | Controller | submissions/detail', (hooks) => {
   setupTest(hooks);
@@ -16,10 +17,7 @@ module('Unit | Controller | submissions/detail', (hooks) => {
     assert.expect(2);
 
     // Mock the global SweetAlert object to always return immediately
-    swal = () =>
-      Promise.resolve({
-        value: 'moo',
-      });
+    const swalStub = Sinon.stub(Swal, 'fire').resolves({ value: true });
 
     const submission = EmberObject.create();
 
@@ -37,13 +35,14 @@ module('Unit | Controller | submissions/detail', (hooks) => {
     );
 
     controller.send('deleteSubmission', submission);
+    swalStub.restore();
   });
 
   test('error message shown on submission deletion error', async function (assert) {
     const submission = {};
 
     // Mock global SweetAlert. Mocks a user clicking OK on the popup
-    swal = Sinon.fake.resolves({ value: true });
+    const swalStub = Sinon.stub(Swal, 'fire').resolves({ value: true });
 
     const controller = this.owner.lookup('controller:submissions/detail');
     const routerService = this.owner.lookup('service:router');
@@ -64,5 +63,6 @@ module('Unit | Controller | submissions/detail', (hooks) => {
     assert.ok(deleteFake.calledOnce, 'Submission handler delete should be called');
     assert.ok(flashFake.calledOnce, 'Flash message should be called');
     assert.equal(transitionFake.callCount, 0, 'Transition should not be called');
+    swalStub.restore();
   });
 });

--- a/tests/unit/controllers/submissions/new-test.js
+++ b/tests/unit/controllers/submissions/new-test.js
@@ -3,6 +3,8 @@ import { A } from '@ember/array';
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
+import Sinon from 'sinon';
 
 module('Unit | Controller | submissions/new', (hooks) => {
   setupTest(hooks);
@@ -345,12 +347,12 @@ module('Unit | Controller | submissions/new', (hooks) => {
     controller.set('model', model);
 
     // Mock global 'swal' for this test
-    swal = () => {
+    const swalStub = Sinon.stub(Swal, 'fire').callsFake(() => {
       assert.ok(true);
       return Promise.resolve({
         value: 'moo',
       });
-    };
+    });
 
     // Having this mocked function run shows that the service will delete the submission
     controller.set(
@@ -369,6 +371,7 @@ module('Unit | Controller | submissions/new', (hooks) => {
     });
 
     controller.send('abort');
+    swalStub.restore();
   });
 
   test('abort should not delete submission if submission.id is undefined', async function (assert) {
@@ -386,12 +389,12 @@ module('Unit | Controller | submissions/new', (hooks) => {
     controller.set('model', model);
 
     // Mock global 'swal' for this test
-    swal = () => {
+    const swalStub = Sinon.stub(Swal, 'fire').callsFake(() => {
       assert.ok(true);
       return Promise.resolve({
         value: 'moo',
       });
-    };
+    });
 
     let deleteSubmissionCalled = false;
 
@@ -413,5 +416,6 @@ module('Unit | Controller | submissions/new', (hooks) => {
     });
 
     controller.send('abort');
+    swalStub.restore();
   });
 });

--- a/tests/unit/controllers/submissions/new/files-test.js
+++ b/tests/unit/controllers/submissions/new/files-test.js
@@ -2,6 +2,8 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
+import Sinon from 'sinon';
 
 module('Unit | Controller | submissions/new/files', (hooks) => {
   setupTest(hooks);
@@ -40,9 +42,10 @@ module('Unit | Controller | submissions/new/files', (hooks) => {
       loadTabAccessed = true;
     };
     assert.strictEqual(controller.get('workflow').getFilesTemp().length, 0);
-    swal = (result) => new Promise((resolve) => assert.ok(true));
+    const swalStub = Sinon.stub(Swal, 'fire').resolves(() => assert.ok(true));
     controller.send('validateAndLoadTab', 'submissions.new.basics');
     assert.false(loadTabAccessed);
+    swalStub.restore();
   });
 
   test('No manuscript files, user not submitter, warns before transition', function (assert) {
@@ -73,9 +76,10 @@ module('Unit | Controller | submissions/new/files', (hooks) => {
     };
     assert.strictEqual(controller.get('workflow').getFilesTemp().length, 0);
     // override swal so it doesn't pop up
-    swal = (result) => new Promise((resolve) => assert.ok(true));
+    const swalStub = Sinon.stub(Swal, 'fire').resolves(() => assert.ok(true));
     controller.send('validateAndLoadTab', 'submissions.new.basics');
     assert.false(loadTabAccessed);
+    swalStub.restore();
   });
 
   test('Multiple manuscript files stops transition', function (assert) {

--- a/tests/unit/controllers/submissions/new/repositories-test.js
+++ b/tests/unit/controllers/submissions/new/repositories-test.js
@@ -3,6 +3,8 @@ import { A } from '@ember/array';
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
+import Sinon from 'sinon';
 
 module('Unit | Controller | submissions/new/repositories', (hooks) => {
   setupTest(hooks);
@@ -36,9 +38,10 @@ module('Unit | Controller | submissions/new/repositories', (hooks) => {
       loadTabAccessed = true;
     };
     // override swal so it doesn't pop up
-    swal = (result) => new Promise((resolve) => assert.ok(true));
+    const swalStub = Sinon.stub(Swal, 'fire').resolves(() => assert.ok(true));
     controller.send('validateAndLoadTab');
     assert.false(loadTabAccessed);
+    swalStub.restore();
   });
 
   test('transition if there are repositories', function (assert) {


### PR DESCRIPTION
This PR upgrades and changes the way sweetalert2 is imported so that the CSP `unsafe-inline` directive is not needed.

Changes:
-Upgrade sweetalert2 to latest version
-Remove sweetalert2 link in index.html
-Import `'sweetalert2/dist/sweetalert2.js'` in component that uses `swal` so that the javascript is imported without the embedded CSS.
-app.import sweetalert2.css in `ember-cli-build.js`
-Update calls to `swal` to use new `swal.fire` function to open dialog
-Update use of `swal` mixin/queue to use new Queue.fire API.

Opened this pass-docker PR with changes to local_env CSP: https://github.com/eclipse-pass/pass-docker/pull/394

To test, build pass-ui and test in pass-docker as usual with local build.  

I also run acceptance-tests locally, and they passed.