### PR TITLE
Fix page reload blank render issues

### DIFF
--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -15,7 +15,7 @@ export default class GrantsIndexController extends Controller {
   constructor() {
     super(...arguments);
 
-    this.faqUrl = this.staticConfig.config.branding.pages.faqUrl;
+    this.faqUrl = this.staticConfig.config?.branding?.pages?.faqUrl;
   }
 
   // TODO Reduce duplication in column definitions

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -38,7 +38,7 @@ export default class SubmissionsIndex extends Controller {
   constructor() {
     super(...arguments);
 
-    this.faqUrl = this.staticConfig.config.branding.pages.faqUrl;
+    this.faqUrl = this.staticConfig.config?.branding?.pages?.faqUrl;
   }
 
   // Columns displayed depend on the user role

--- a/app/controllers/thanks.js
+++ b/app/controllers/thanks.js
@@ -14,6 +14,6 @@ export default class ThanksController extends Controller {
   constructor() {
     super(...arguments);
 
-    this.faqUrl = this.staticConfig.config.branding.pages.faqUrl;
+    this.faqUrl = this.staticConfig.config?.branding?.pages?.faqUrl;
   }
 }

--- a/app/router.js
+++ b/app/router.js
@@ -10,7 +10,6 @@ class Router extends EmberRouter {
 Router.map(function () {
   this.route('dashboard', { path: '/' });
   this.route('submissions', function () {
-    this.route('detail', { path: '/*path' });
     this.route('detail', { path: '/:submission_id' });
     this.route('new', function () {
       this.route('grants');

--- a/app/routes/check-session-route.js
+++ b/app/routes/check-session-route.js
@@ -33,6 +33,8 @@ export default class CheckSessionRouteRoute extends Route {
     if ([401, 403].includes(Number(errorObject.status))) {
       this.session.set('attemptedTransition', transition);
       await this.session.invalidate();
+    } else {
+      this.errorHandler.handleError(error);
     }
   }
 }

--- a/app/services/error-handler.js
+++ b/app/services/error-handler.js
@@ -35,7 +35,7 @@ export default class ErrorHandlerService extends Service {
     } else if (error.status == 403 || error.payload == 403) {
       // Some authorization issue
       this.handleAuthorizationProblem(error);
-    } else if (error.status == 404) {
+    } else if (error.status == 404 || error.message?.includes('returned a 404')) {
       // Failure to find a resource
       this.handleNotFound(error);
     } else {

--- a/tests/unit/services/error-handler-test.js
+++ b/tests/unit/services/error-handler-test.js
@@ -1,12 +1,41 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Service | error handler', (hooks) => {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let service = this.owner.lookup('service:error-handler');
-    assert.ok(service);
+  test('it handles 404 message error', function (assert) {
+    // GIVEN
+    let errorHandler = this.owner.lookup('service:error-handler');
+    const error = {
+      message: 'test returned a 404 status code',
+    };
+    const handleNotFoundStub = sinon.stub(errorHandler, 'handleNotFound');
+
+    // WHEN
+    errorHandler.handleError(error);
+
+    // THEN
+    sinon.assert.calledOnce(handleNotFoundStub);
+    assert.ok(errorHandler);
+    handleNotFoundStub.restore();
+  });
+
+  test('it handles 404 status code', function (assert) {
+    // GIVEN
+    let errorHandler = this.owner.lookup('service:error-handler');
+    const error = {
+      status: 404,
+    };
+    const handleNotFoundStub = sinon.stub(errorHandler, 'handleNotFound');
+
+    // WHEN
+    errorHandler.handleError(error);
+
+    // THEN
+    sinon.assert.calledOnce(handleNotFoundStub);
+    assert.ok(errorHandler);
+    handleNotFoundStub.restore();
   });
 });


### PR DESCRIPTION
This PR fixes a few issues with the UI rendering blank:

- Reload of page with query params such as filter on Submission page and refresh.
- In browser, enter valid path but invalid ID such as https://stage.pass.jhu.edu/app/submissions/999999.  Now shows 404 page.
- In browser, enter path like `/submissions/new/basicmmm` caused infinite page reload error.  Now shows 404 page.
- Other errors other than 401 and 403 on page load. Now shows dialog with error message.