### PR TITLE
Fix submit confirmation bug

### DIFF
--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -374,7 +374,6 @@ export default class SubmissionsDetail extends Controller {
     if (!validResults && reposWithAgreementText.length > 0) {
       return;
     }
-    console.log(result.value);
     let reposThatUserAgreedToDeposit = reposWithAgreementText.filter((repo, index) => {
       if (result.value[index] === 1) {
         return repo;


### PR DESCRIPTION
This PR fixes the bug where if a submission is only being deposited into PMC, the submit confirmation dialog will now work as expected.  It also has some refactoring to try to make the conditional logic try a bit easier to understand.

Good to test confirmation dialog on Workflow Review page on Submit button, and the Submit button on the Submission Details page in the proxy workflow request approval use case.