### PR TITLE
Fix infinite error load issue on proxy submission details refresh

### DIFF
--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -24,7 +24,7 @@ export default class DetailRoute extends CheckSessionRoute {
     });
 
     const sub = await this.store.findRecord('submission', params.submission_id, {
-      include: 'publication.journal,repositories,preparers',
+      include: 'publication.journal,repositories,preparers,submitter',
     });
     const publication = await sub.get('publication');
     const repoCopies = await this.store.query('repositoryCopy', {


### PR DESCRIPTION
This fixes an issue found during testing.  Here is when the issue happened:

- Running pass-docker locally
- Login as nih-user
- Start new submission
- Submit for proxy for staff1 user
- Go all the way through and Request approval
- Go to Submissions page and click the submission title link to view the details page
- Refresh the browser, this is where there would be an infinite error issue.

The issue was the `submitter` was not included when getting the submission.