### PR TITLE
Configure SurveyJS not to load default Google fonts

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,7 +7,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 import 'ember-modal-dialog/app/styles/ember-modal-dialog/ember-modal-structure.css';
 import 'ember-modal-dialog/app/styles/ember-modal-dialog/ember-modal-appearance.css';
 import 'sweetalert2/dist/sweetalert2.css';
-import 'survey-core/survey-core.css';
+import 'survey-core/survey-core.fontless.min.css';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;


### PR DESCRIPTION
This means that the fonts configured by the branding will be used by SurveyJS and that CSP rules for google fonts are not needed.