### PR TITLE
Validate ORCID iDs

### DIFF
--- a/app/instance-initializers/surveyjs.js
+++ b/app/instance-initializers/surveyjs.js
@@ -1,0 +1,50 @@
+// Setup custom SurveyJS validation functions
+import { FunctionFactory } from 'survey-core';
+
+// Generates check digit as per ISO 7064 11,2.
+function generateCheckDigit(baseDigits) {
+  let total = 0;
+  for (let i = 0; i < baseDigits.length; i++) {
+    let digit = parseInt(baseDigits.charAt(i), 10);
+    total = (total + digit) * 2;
+  }
+  let remainder = total % 11;
+  let result = (12 - remainder) % 11;
+  return result === 10 ? 'X' : String(result);
+}
+
+// Check that the ORCID is valid.
+// The ORCID can be in the format: 0000-0002-1825-0097 or https://orcid.org/0000-0002-1825-0097
+function validateOrcid([orcid]) {
+  if (!orcid) {
+    return false;
+  }
+
+  let prefix = 'https://orcid.org/';
+
+  if (orcid.startsWith(prefix)) {
+    orcid = orcid.slice(prefix.length);
+  }
+
+  if (orcid.match(/^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]{1}$/)) {
+    let baseDigits = orcid.replace(/-/g, '').slice(0, 15);
+    let checkDigit = orcid.slice(-1).toUpperCase();
+    let calculatedCheckDigit = generateCheckDigit(baseDigits);
+
+    if (checkDigit !== calculatedCheckDigit) {
+      return false;
+    }
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+export function initialize(owner) {
+  FunctionFactory.Instance.register('validateOrcid', validateOrcid);
+}
+
+export default {
+  initialize,
+};

--- a/app/services/schema/surveyjs.json
+++ b/app/services/schema/surveyjs.json
@@ -1,5 +1,6 @@
 {
     "checkErrorsMode": "onValueChanged",
+    "textUpdateMode": "onTyping",
     "elements": [
         {
             "name": "abstract",
@@ -20,7 +21,19 @@
                 {
                     "name": "orcid",
                     "type": "text",
-                    "title": "ORCiD"
+                    "title": "ORCID iD",
+                    "validators": [{
+                        "type": "expression",
+                        "expression": "{panel.orcid} empty or validateOrcid({panel.orcid})",
+                        "text": "Please enter a valid ORCID iD."
+                    }]
+                },
+                {
+                    "name": "orcid-link",
+                    "type": "html",
+                    "title": "ORCID iD Link",
+                    "html": "<a href='{panel.orcid}' target='_blank' rel='noopener noreferrer' aria-label='View ORCID record'><img src='/app/ORCID-iD_icon_unauth_24x24.png' alt='ORCID iD'/> {panel.orcid} (unauthenticated)</a>",
+                    "visibleIf": "{panel.orcid} notempty and validateOrcid({panel.orcid})"
                 }
             ]
         },

--- a/tests/unit/instance-initializers/surveyjs-test.js
+++ b/tests/unit/instance-initializers/surveyjs-test.js
@@ -1,0 +1,39 @@
+import Application from '@ember/application';
+
+import config from 'pass-ui/config/environment';
+import { initialize } from 'pass-ui/instance-initializers/surveyjs';
+import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
+import { run } from '@ember/runloop';
+
+module('Unit | Instance Initializer | surveyjs', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {
+      modulePrefix = config.modulePrefix;
+      podModulePrefix = config.podModulePrefix;
+      Resolver = Resolver;
+    };
+
+    this.TestApplication.instanceInitializer({
+      name: 'initializer under test',
+      initialize,
+    });
+
+    this.application = this.TestApplication.create({
+      autoboot: false,
+    });
+
+    this.instance = this.application.buildInstance();
+  });
+  hooks.afterEach(function () {
+    run(this.instance, 'destroy');
+    run(this.application, 'destroy');
+  });
+
+  // TODO: Replace this with your real tests.
+  test('it works', async function (assert) {
+    await this.instance.boot();
+
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
As an ORCID iD is entered in the metadata, its structure is validated. Both the long URL and short forms are supported. In addition a link formatted according to the guidelines, https://info.orcid.org/documentation/integration-guide/orcid-id-display-guidelines/, is added.

Note that having a user do full ORCID authentication to validate an ORCID iD does not make sense in the general case. A submitter or preparer would only be able to add their own ORCID iD.

TODO:
  * Normalize the ORCID iDs to the long form.
  * Decide if we should get an API key so we can actually lookup the person. What would we do with this info? Correct the name which was entered?