### PR TITLE
Fix workflow grants pagination

### DIFF
--- a/app/components/workflow-grants/index.hbs
+++ b/app/components/workflow-grants/index.hbs
@@ -80,18 +80,18 @@
   {{#if (gt this.pageCount "1")}}
     <nav id="grants-selection-nav" aria-label="...">
       <ul class="pagination justify-content-center">
-        <li class="page-item active">
+        <li class="page-item active btn">
           <a class="fa fa-angle-left" {{action "prevPage"}}></a>
         </li>
-        <li class="page-item">
-          <a class="page-link">
+        <li class="page-item d-flex align-items-center">
+          <span>
             Page
             {{this.pageNumber}}
             of
             {{this.pageCount}}
-          </a>
+          </span>
         </li>
-        <li class="page-item active">
+        <li class="page-item active btn">
           <a class="fa fa-angle-right" {{action "nextPage"}}></a>
         </li>
       </ul>

--- a/app/components/workflow-grants/index.js
+++ b/app/components/workflow-grants/index.js
@@ -108,26 +108,25 @@ export default class WorkflowGrants extends Component {
   };
 
   updateGrants = task(async () => {
-    let info = {};
-
     const userId = await this.args.submission.submitter.id;
-    // TODO: Ignore date filter for now ( >= 2011-01-01 )
     const grantQuery = {
       filter: {
         grant: `pi.id==${userId},coPis.id==${userId}`,
       },
       sort: '-endDate',
       page: {
-        offset: (this.pageNumber - 1) * this.pageSize,
-        limit: this.pageSize,
+        number: this.pageNumber,
+        size: this.pageSize,
+        totals: true,
       },
     };
-    let results = await this.store.query('grant', grantQuery);
-
-    this.submitterGrants = results;
-    // TODO: How do we get pagination to work with store.query like this?
-    this.totalGrants = info.total;
-    this.pageCount = Math.ceil(info.total / this.pageSize);
+    const results = await this.store.query('grant', grantQuery).then((data) => ({
+      grants: data,
+      page: data.meta.page,
+    }));
+    this.submitterGrants = results.grants;
+    this.totalGrants = results.page.totalRecords;
+    this.pageCount = results.page.totalPages;
   });
 
   /**

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -198,7 +198,19 @@ export default function (config) {
 
       // Grants
       this.get('/data/grant/:id', (schema, request) => schema.find('grant', request.params.id));
-      this.get('/data/grant', (schema, request) => schema.all('grant'));
+      this.get('/data/grant', function (schema, request) {
+        const grantsModel = schema.grant.all();
+        const grants = this.serialize(grantsModel);
+        return {
+          ...grants,
+          meta: {
+            page: {
+              totalRecords: 5,
+              totalPages: 1,
+            },
+          },
+        };
+      });
 
       this.get('/data/repositoryCopy/:id', (schema, request) => schema.find('repositoryCopy', request.params.id));
       this.get('/data/repositoryCopy', (schema, request) => schema.none('repositoryCopy'));

--- a/tests/integration/components/workflow-grants-test.js
+++ b/tests/integration/components/workflow-grants-test.js
@@ -29,6 +29,7 @@ module('Integration | Component | workflow grants', (hooks) => {
       EmberObject.create({ id: 3, awardNumber: '3', projectName: 'Moo 3' }),
       EmberObject.create({ id: 4, awardNumber: '4', projectName: 'Moo 4' }),
     ]);
+    grants.meta = { page: { totalRecords: 4, totalPages: 1 } };
 
     const mockStaticConfig = Service.extend({
       getStaticConfig: () =>


### PR DESCRIPTION
Now if the the user has more than 10 grants, the workflow grants page will show pagination controls allowing the user see all their grants.

There is also this pass-docker that adds grants for `nih-user` so they have more than 10 grants for testing purposes: https://github.com/eclipse-pass/pass-docker/pull/400