### PR TITLE
Fix Invalid DOI error message

### DIFF
--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -68,10 +68,9 @@ export default class DoiService extends Service {
     const ancientDOIRegExp = /^(https?:\/\/(dx\.)?doi\.org\/)?10.1002\/[^\s]+$/i;
     if (doi == null || !doi) {
       return false;
-    } else if (newDOIRegExp.test(doi) === true || ancientDOIRegExp.test(doi) === true) {
-      return true;
     }
-    return false;
+    const testDoi = doi.trim();
+    return newDOIRegExp.test(testDoi) === true || ancientDOIRegExp.test(testDoi) === true;
   }
 
   formatDOI(doi) {

--- a/tests/acceptance/nih-submission-test.js
+++ b/tests/acceptance/nih-submission-test.js
@@ -26,7 +26,7 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     assert.strictEqual(currentURL(), '/submissions/new/basics');
     assert.dom('[data-test-doi-input]').exists();
-    await fillIn('[data-test-doi-input]', '10.1039/c7an01256j');
+    await fillIn('[data-test-doi-input]', '10.1039/c7an01256j ');
 
     await waitFor('.flash-message.alert.alert-success');
     assert.dom('.flash-message.alert.alert-success').exists({ count: 1 });


### PR DESCRIPTION
If a DOI had whitespace at the beginning or end, the regex would fail causing the "Invalid DOI" error message for a second until it was later trimmed after lookup.  This PR trims the DOI value before regex testing.