### PR TITLE
Refactor grant selection table to be more informative

### DIFF
--- a/app/components/grant-link-newtab-cell/index.hbs
+++ b/app/components/grant-link-newtab-cell/index.hbs
@@ -1,4 +1,10 @@
 {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-<LinkTo @route="grants.detail" @model={{@record.id}} target="_blank" rel="noopener noreferrer" {{on "click" this.stopPropagation}}>
+<LinkTo
+  @route="grants.detail"
+  @model={{@record.id}}
+  target="_blank"
+  rel="noopener noreferrer"
+  {{on "click" this.stopPropagation}}
+>
   {{get @record @column.propertyName}}
 </LinkTo>

--- a/app/components/grant-link-newtab-cell/index.hbs
+++ b/app/components/grant-link-newtab-cell/index.hbs
@@ -1,4 +1,4 @@
 {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-<LinkTo @route="grants.detail" @model={{@record.id}} target="_blank">
+<LinkTo @route="grants.detail" @model={{@record.id}} target="_blank" rel="noopener noreferrer">
   {{get @record @column.propertyName}}
 </LinkTo>

--- a/app/components/grant-link-newtab-cell/index.hbs
+++ b/app/components/grant-link-newtab-cell/index.hbs
@@ -1,4 +1,4 @@
 {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-<LinkTo @route="grants.detail" @model={{@record.id}} @target="_blank">
+<LinkTo @route="grants.detail" @model={{@record.id}} target="_blank">
   {{get @record @column.propertyName}}
 </LinkTo>

--- a/app/components/grant-link-newtab-cell/index.hbs
+++ b/app/components/grant-link-newtab-cell/index.hbs
@@ -1,4 +1,4 @@
 {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-<LinkTo @route="grants.detail" @model={{@record.id}} target="_blank" rel="noopener noreferrer">
+<LinkTo @route="grants.detail" @model={{@record.id}} target="_blank" rel="noopener noreferrer" {{on "click" this.stopPropagation}}>
   {{get @record @column.propertyName}}
 </LinkTo>

--- a/app/components/grant-link-newtab-cell/index.js
+++ b/app/components/grant-link-newtab-cell/index.js
@@ -1,4 +1,11 @@
 /* eslint-disable ember/no-empty-glimmer-component-classes */
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
-export default class GrantLinkNewtabCell extends Component {}
+export default class GrantLinkNewtabCell extends Component {
+  // Prevent the click from triggering the row selection in the table
+  @action
+  stopPropagation(event) {
+    event.stopPropagation();
+  }
+}

--- a/app/components/grant-title-date-cell/index.hbs
+++ b/app/components/grant-title-date-cell/index.hbs
@@ -1,1 +1,0 @@
-{{@record.projectName}} ({{format-date @record.startDate}} - {{format-date @record.endDate}})

--- a/app/components/grant-title-date-cell/index.js
+++ b/app/components/grant-title-date-cell/index.js
@@ -1,4 +1,0 @@
-/* eslint-disable ember/no-empty-glimmer-component-classes */
-import Component from '@glimmer/component';
-
-export default class GrantTitleDateCell extends Component {}

--- a/app/components/submission-funding-table/index.hbs
+++ b/app/components/submission-funding-table/index.hbs
@@ -15,7 +15,8 @@
             @route="grants.detail"
             @model={{grant}}
             class="text-nowrap"
-            target="_blank" rel="noopener noreferrer"
+            target="_blank"
+            rel="noopener noreferrer"
           >{{grant.awardNumber}}</LinkTo>
         </td>
         <td class="projectname-date-column">{{grant.projectName}}

--- a/app/components/submission-funding-table/index.hbs
+++ b/app/components/submission-funding-table/index.hbs
@@ -15,7 +15,7 @@
             @route="grants.detail"
             @model={{grant}}
             class="text-nowrap"
-            @target="_blank"
+            target="_blank"
           >{{grant.awardNumber}}</LinkTo>
         </td>
         <td class="projectname-date-column">{{grant.projectName}}

--- a/app/components/submission-funding-table/index.hbs
+++ b/app/components/submission-funding-table/index.hbs
@@ -15,7 +15,7 @@
             @route="grants.detail"
             @model={{grant}}
             class="text-nowrap"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
           >{{grant.awardNumber}}</LinkTo>
         </td>
         <td class="projectname-date-column">{{grant.projectName}}

--- a/app/components/workflow-grants/index.hbs
+++ b/app/components/workflow-grants/index.hbs
@@ -55,8 +55,8 @@
         @columns={{this.grantColumns}}
         @columnComponents={{hash
           grantLinkNewtabCell=(component "grant-link-newtab-cell")
-          grantTitleDateCell=(component "grant-title-date-cell")
           selectRowToggle=(component "select-row-toggle")
+          dateCell=(component "date-cell")
         }}
         @themeInstance={{this.themeInstance}}
         @showColumnsDropdown={{false}}

--- a/app/components/workflow-grants/index.js
+++ b/app/components/workflow-grants/index.js
@@ -38,9 +38,28 @@ export default class WorkflowGrants extends Component {
       disableSorting: true,
     },
     {
-      title: 'Project name (funding period)',
-      className: 'projectname-date-column',
-      component: 'grantTitleDateCell',
+      propertyName: 'projectName',
+      title: 'Project Name',
+      className: 'projectname-column',
+      disableSorting: true,
+    },
+    {
+      propertyName: 'startDate',
+      title: 'Start',
+      className: 'date-column',
+      component: 'dateCell',
+      disableSorting: true,
+    },
+    {
+      propertyName: 'endDate',
+      title: 'End',
+      className: 'date-column',
+      component: 'dateCell',
+      disableSorting: true,
+    },
+    {
+      propertyName: 'awardStatus',
+      title: 'Status',
       disableSorting: true,
     },
     {

--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -78,11 +78,11 @@ export default class GrantDetailsController extends Controller {
   };
 
   get itemsCount() {
-    return this.queuedModel.submissions.meta?.page?.totalRecords;
+    return this.queuedModel.submissions?.meta?.page?.totalRecords;
   }
 
   get pagesCount() {
-    return this.queuedModel.submissions.meta?.page?.totalPages;
+    return this.queuedModel.submissions?.meta?.page?.totalPages;
   }
 
   @action

--- a/tests/acceptance/nih-submission-test.js
+++ b/tests/acceptance/nih-submission-test.js
@@ -46,12 +46,12 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     await click('[data-test-workflow-basics-next]');
 
-    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
     assert.strictEqual(currentURL(), '/submissions/new/grants');
     assert
-      .dom('[data-test-grants-selection-table] tbody tr td.projectname-date-column')
+      .dom('[data-test-grants-selection-table] tbody tr td.projectname-column')
       .includesText('Regulation of Synaptic Plasticity in Visual Cortex');
-    await click('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await click('[data-test-grants-selection-table] tbody tr td.projectname-column');
     await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
     assert
       .dom('[data-test-submission-funding-table] tbody tr td.projectname-date-column')
@@ -220,12 +220,12 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     await click('[data-test-workflow-basics-next]');
 
-    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
     assert.strictEqual(currentURL(), '/submissions/new/grants');
     assert
-      .dom('[data-test-grants-selection-table] tbody tr td.projectname-date-column')
+      .dom('[data-test-grants-selection-table] tbody tr td.projectname-column')
       .includesText('Regulation of Synaptic Plasticity in Visual Cortex');
-    await click('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await click('[data-test-grants-selection-table] tbody tr td.projectname-column');
     await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
     assert
       .dom('[data-test-submission-funding-table] tbody tr td.projectname-date-column')
@@ -390,12 +390,12 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     await click('[data-test-workflow-basics-next]');
 
-    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
     assert.strictEqual(currentURL(), '/submissions/new/grants');
     assert
-      .dom('[data-test-grants-selection-table] tbody tr td.projectname-date-column')
+      .dom('[data-test-grants-selection-table] tbody tr td.projectname-column')
       .includesText('Regulation of Synaptic Plasticity in Visual Cortex');
-    await click('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await click('[data-test-grants-selection-table] tbody tr td.projectname-column');
     await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
     assert
       .dom('[data-test-submission-funding-table] tbody tr td.projectname-date-column')
@@ -418,7 +418,7 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     await click('[data-test-workflow-basics-next]');
 
-    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
     assert.strictEqual(currentURL(), '/submissions/new/grants');
     await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
     assert
@@ -532,12 +532,12 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     await click('[data-test-workflow-basics-next]');
 
-    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
     assert.strictEqual(currentURL(), '/submissions/new/grants');
     assert
-      .dom('[data-test-grants-selection-table] tbody tr td.projectname-date-column')
+      .dom('[data-test-grants-selection-table] tbody tr td.projectname-column')
       .includesText('Regulation of Synaptic Plasticity in Visual Cortex');
-    await click('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await click('[data-test-grants-selection-table] tbody tr td.projectname-column');
     await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
     assert
       .dom('[data-test-submission-funding-table] tbody tr td.projectname-date-column')
@@ -669,12 +669,12 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     await click('[data-test-workflow-basics-next]');
 
-    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
     assert.strictEqual(currentURL(), '/submissions/new/grants');
     assert
-      .dom('[data-test-grants-selection-table] tbody tr td.projectname-date-column')
+      .dom('[data-test-grants-selection-table] tbody tr td.projectname-column')
       .includesText('Regulation of Synaptic Plasticity in Visual Cortex');
-    await click('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await click('[data-test-grants-selection-table] tbody tr td.projectname-column');
     await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
     assert
       .dom('[data-test-submission-funding-table] tbody tr td.projectname-date-column')
@@ -728,12 +728,12 @@ module('Acceptance | submission', function (hooks) {
     await waitFor('[data-test-workflow-basics-next]');
     await click('[data-test-workflow-basics-next]');
 
-    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+    await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
     assert.strictEqual(currentURL(), '/submissions/new/grants');
     assert
-      .dom('[data-test-grants-selection-table] tbody tr:nth-child(10) td.projectname-date-column')
+      .dom('[data-test-grants-selection-table] tbody tr:nth-child(10) td.projectname-column')
       .includesText('Pre-Study of wild-type');
-    await click('[data-test-grants-selection-table] tbody tr:nth-child(10) td.projectname-date-column');
+    await click('[data-test-grants-selection-table] tbody tr:nth-child(10) td.projectname-column');
     await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
     assert
       .dom('[data-test-submission-funding-table] tbody tr td.projectname-date-column')

--- a/tests/acceptance/proxy-submission-test.js
+++ b/tests/acceptance/proxy-submission-test.js
@@ -106,12 +106,12 @@ module('Acceptance | proxy submission', function (hooks) {
     await click('[data-test-workflow-basics-next]');
 
     if (hasAccount) {
-      await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+      await waitFor('[data-test-grants-selection-table] tbody tr td.projectname-column');
       assert.strictEqual(currentURL(), '/submissions/new/grants');
       assert
-        .dom('[data-test-grants-selection-table] tbody tr td.projectname-date-column')
+        .dom('[data-test-grants-selection-table] tbody tr td.projectname-column')
         .includesText('Regulation of Synaptic Plasticity in Visual Cortex');
-      await click('[data-test-grants-selection-table] tbody tr td.projectname-date-column');
+      await click('[data-test-grants-selection-table] tbody tr td.projectname-column');
       await waitFor('[data-test-submission-funding-table] tbody tr td.projectname-date-column');
       assert
         .dom('[data-test-submission-funding-table] tbody tr td.projectname-date-column')


### PR DESCRIPTION
* Changes the grant links on the grant selection and selected grants tables in the workflow to open the grant details page in a new tab
* Refactors the grant selection table to have start/end dates in columns separated from the project name as well as the status in a new column

I'm planning to ignore the sonar qube failure. It is related to duplicated code in tests and is captured in https://github.com/eclipse-pass/main/issues/1177.